### PR TITLE
Use Clapper sink when available

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -163,6 +163,10 @@ class VideoWallpaperWindow {
             // Try to find "clappersink" for best performance
             let sink = Gst.ElementFactory.make('clappersink', 'clappersink');
 
+            // Try "gtk4paintablesink" from gstreamer-rs plugins as 2nd best choice
+            if (!sink)
+                sink = Gst.ElementFactory.make('gtk4paintablesink', 'gtk4paintablesink');
+
             if (sink) {
                 widget = this._getWidgetFromSink(sink);
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -25,8 +25,7 @@ const applicationId = "io.github.jeffshee.hanabi_renderer";
 const isDebugMode = true;
 const waitTime = 500;
 
-let display = Gdk.Display.open(GLib.getenv("DISPLAY"));
-let isUsingX11 = display.constructor.$gtype.name === 'GdkX11Display'
+let display = null;
 let windowed = false;
 let windowConfig = { width: 1920, height: 1080 }
 let codePath = "";
@@ -127,6 +126,9 @@ class VideoWallpaperWindow {
         this._app = app;
         this._window = null;
         this._label = null;
+
+        if (!display)
+            display = Gdk.Display.get_default();
 
         // Load CSS with custom style
         let cssProvider = new Gtk.CssProvider();
@@ -238,7 +240,9 @@ renderer.connect("activate", (app) => {
         // Hide the content at first
         window.hideWallpaper();
         activeWindow.present();
+
         // Skip taskbar (X11 only)
+        let isUsingX11 = (display && display.constructor.$gtype.name === 'GdkX11Display');
         if (isUsingX11) {
             // No such method under Wayland. Instead it is done by gnome-extension.
             activeWindow.get_native().get_surface().set_skip_taskbar_hint(true);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -126,7 +126,6 @@ class VideoWallpaperWindow {
     constructor(app) {
         this._app = app;
         this._window = null;
-        this._box = null;
         this._label = null;
 
         // Load CSS with custom style
@@ -150,11 +149,6 @@ class VideoWallpaperWindow {
         this._windowContext = this._window.get_style_context();
         this._windowContext.add_class("desktopwindow");
 
-        this._box = new Gtk.Box({
-            halign: Gtk.Align.FILL,
-            valign: Gtk.Align.FILL,
-        });
-
         // The constructor of MediaFile doesn't work in gjs.
         // Have to call the `new_for_xxx` function here.
         this._media = Gtk.MediaFile.new_for_filename(filePath);
@@ -172,10 +166,7 @@ class VideoWallpaperWindow {
             paintable: this._media,
         });
 
-        this._box.append(this._picture);
-        this._box.show();
-
-        this._window.set_child(this._box);
+        this._window.set_child(this._picture);
     }
 
     /**
@@ -201,11 +192,11 @@ class VideoWallpaperWindow {
     }
 
     showWallpaper() {
-        this._box.visible = true;
+        this._window.child.visible = true;
     }
 
     hideWallpaper() {
-        this._box.visible = false;
+        this._window.child.visible = false;
     }
 }
 


### PR DESCRIPTION
When `clappersink` is installed use it for improved performance. Clapper sink also efficiently handles all kinds of subtitles (including animated karaoke) for additional benefit. When unavailable, try to fallback to `gtk4paintablesink` from gstreamer-rs plugins as 2nd best choice. Finally fallback to stock GTK media playback implementation (old code path).

**Opening as a draft, cause I did not have time yet to test it properly (only tested from command line).**

---

TO TEST:
1. Make sure `clappersink` is available (check with `gst-inspect-1.0 clappersink`).
2. Run renderer.js from this repo with `./renderer.js --windowed 640:480 --nohide -F /path/to/media.mp4`
3. Name of the used sink is included in window title (should say `clappersink`).

**Intel/AMD Wayland users** can additionally benefit from using new VA plugin (not enabled by default) that uses DMABuf sharing with the sink. To do so, try running above with `GST_PLUGIN_FEATURE_RANK=vah264dec:300,vavp9dec:300` env.

@jeffshee 
It is possible to enable and use VA plugin from within the code (not part of this MR). Since VA is new and still considered experimental I did not do it here. Let me know if you want me to go with it, and I can do another MR that enables it. For now can be tested from terminal as I written above.

Fixes #18 