### PR TITLE
GStreamer decoders rank manipulation improvements

### DIFF
--- a/src/prefs.js
+++ b/src/prefs.js
@@ -64,9 +64,9 @@ function fillPreferencesWindow(window) {
     );
     prefsRowBoolean(
         experimentalGroup,
-        "Experimental VA plugins",
-        "enable-vah264dec-vavp9dec",
-        "Enable vah264dec and vavp9dec which improve performance for Intel/AMD Wayland users"
+        "Experimental VA plugin",
+        "enable-va",
+        "Enable VA decoders which improve performance for Intel/AMD Wayland users"
     );
     // Add our page to the window
     window.add(page);

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -68,6 +68,12 @@ function fillPreferencesWindow(window) {
         "enable-va",
         "Enable VA decoders which improve performance for Intel/AMD Wayland users"
     );
+    prefsRowBoolean(
+        experimentalGroup,
+        "Nvidia stateless decoders",
+        "enable-nvsl",
+        "Use new stateless Nvidia decoders"
+    );
     // Add our page to the window
     window.add(page);
 }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -43,6 +43,9 @@ const isDebugMode = extSettings ? extSettings.get_boolean("debug-mode") : true;
 const isEnableVADecoders = extSettings
     ? extSettings.get_boolean("enable-va")
     : false;
+const isEnableNvSl = extSettings
+    ? extSettings.get_boolean("enable-nvsl")
+    : false;
 
 let windowed = false;
 let windowConfig = { width: 1920, height: 1080 };
@@ -181,6 +184,12 @@ class VideoWallpaperWindow {
         this._windowContext = this._window.get_style_context();
         this._windowContext.add_class("desktopwindow");
 
+        // Software libav decoders have "primary" rank, set Nvidia higher
+        // to use NVDEC hardware acceleration
+        this._setPluginDecodersRank("nvcodec", Gst.Rank.PRIMARY + 1, isEnableNvSl);
+
+        // Legacy "vaapidecodebin" have rank "primary + 2",
+        // we need to set VA higher then that to be used
         if (isEnableVADecoders)
             this._setPluginDecodersRank("va", Gst.Rank.PRIMARY + 3);
 
@@ -282,7 +291,7 @@ class VideoWallpaperWindow {
         return widget;
     }
 
-    _setPluginDecodersRank(pluginName, rank)
+    _setPluginDecodersRank(pluginName, rank, useStateless = false)
     {
         const gstRegistry = Gst.Registry.get();
         const features = gstRegistry.get_feature_list_by_plugin(pluginName);
@@ -293,9 +302,14 @@ class VideoWallpaperWindow {
             if (!featureName.endsWith("dec") && !featureName.endsWith("postproc"))
                 continue;
 
+            const isStateless = featureName.includes("sl");
+
+            if (isStateless != useStateless)
+                continue;
+
             const oldRank = feature.get_rank();
 
-            if(rank == oldRank)
+            if (rank == oldRank)
                 continue;
 
             feature.set_rank(rank);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -220,11 +220,9 @@ class VideoWallpaperWindow {
 
         if (!widget) return null;
 
-        this._play = new GstPlay.Play({
-            video_renderer: new GstPlay.PlayVideoOverlayVideoRenderer({
-                video_sink: sink,
-            }),
-        });
+        this._play = GstPlay.Play.new(
+            GstPlay.PlayVideoOverlayVideoRenderer.new_with_sink(null, sink)
+        );
         this._adapter = GstPlay.PlaySignalAdapter.new(this._play);
 
         // Loop video

--- a/src/schemas/io.github.jeffshee.hanabi-extension.gschema.xml
+++ b/src/schemas/io.github.jeffshee.hanabi-extension.gschema.xml
@@ -45,13 +45,11 @@
             <description>Print debug messages to log</description>
         </key>
 
-        <key name="enable-vah264dec-vavp9dec" type="b">
+        <key name="enable-va" type="b">
             <default>false</default>
-            <summary>Experimental VA plugins</summary>
-            <description>Enable vah264dec and vavp9dec which improve performance for Intel/AMD
-                Wayland users</description>
+            <summary>Experimental VA plugin</summary>
+            <description>Enable VA decoders which improve performance for Intel/AMD Wayland users</description>
         </key>
-
 
     </schema>
 </schemalist>

--- a/src/schemas/io.github.jeffshee.hanabi-extension.gschema.xml
+++ b/src/schemas/io.github.jeffshee.hanabi-extension.gschema.xml
@@ -51,5 +51,11 @@
             <description>Enable VA decoders which improve performance for Intel/AMD Wayland users</description>
         </key>
 
+        <key name="enable-nvsl" type="b">
+            <default>false</default>
+            <summary>Nvidia stateless decoders</summary>
+            <description>Use new stateless Nvidia decoders</description>
+        </key>
+
     </schema>
 </schemalist>


### PR DESCRIPTION
Setting env vars from within code is never a good idea, use dedicated public methods to do so instead.
Also do not limit users to just `h264` and `vp9`. Enable all decoders that come from VA plugin.

I did small correction in code. Should be "VA plugin" (not plural). There is only one plugin, but it has multiple features in it. We are mainly interested in features that are decoders here.

I also put a small fix/workaround for `GstPlay` debug errors as part of this MR in separate commit while I was at it.

Added an experimental option to use new Nvidia stateless decoders.