### PR TITLE
fix: workaround for distro that ship with older gtk/deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ If the GNOME shell keeps crashing, you can try to disable the extension using tt
 gnome-extensions disable hanabi-extension@jeffshee.github.io
 ```
 
-### Known issues
+### Distro-specific guide
+
+[Guide for Pop!\_OS 22.04](docs/popos-22-04.md)
+
+### Troubleshooting
 
 1. The video doesn't play / The extension is enabled but nothing happens  
    The GTK4 media backend is not pre-installed on some distributions (such as PopOS).

--- a/docs/popos-22-04.md
+++ b/docs/popos-22-04.md
@@ -1,0 +1,50 @@
+# Guide for Pop!\_OS 22.04
+
+_Note: Pop!\_OS has a heavily customized GNOME Shell, your mileage may vary._
+
+## 1. System update (recommended)
+
+```bash
+sudo apt update && sudo apt upgrade
+```
+
+## 2. Install multimedia codecs
+
+```bash
+sudo apt install -y ubuntu-restricted-extras
+sudo apt install -y gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-plugins-good libavcodec-extra gstreamer1.0-libav chromium-codecs-ffmpeg-extra libdvd-pkg
+```
+
+Reference: [https://support.system76.com/articles/codecs/](https://support.system76.com/articles/codecs/)
+
+## 3. Install dependencies
+
+```bash
+# Meson
+sudo apt install meson
+
+# GTK4 media backend
+sudo apt install libgtk-4-media-gstreamer
+
+# GstPlay and GstAudio
+sudo apt install gir1.2-gst-plugins-base-1.0 gir1.2-gst-plugins-bad-1.0
+```
+
+## 4. Build Clapper from source (optional, better performance)
+
+```bash
+# Build dependencies
+sudo apt install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-good1.0-dev libgstreamer-plugins-bad1.0-dev libgtk-4-dev
+
+# Build & install
+git clone https://github.com/Rafostar/clapper.git
+cd clapper
+meson builddir --prefix=/usr/local
+sudo meson install -C builddir
+```
+
+Reference: [https://github.com/Rafostar/clapper](https://github.com/Rafostar/clapper)
+
+## 5. Install Hanabi Gnome Extensions
+
+Refer to the README

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -21,6 +21,8 @@ const {Adw, Gio, Gtk} = imports.gi;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 
+const haveContentFit = Gtk.get_minor_version() >= 8;
+
 const settings = ExtensionUtils.getSettings(
     'io.github.jeffshee.hanabi-extension'
 );
@@ -260,7 +262,13 @@ function prefsRowFitMode(prefsGroup) {
         model: items,
         selected: settings.get_int('content-fit'),
     });
-    row.set_tooltip_markup(tooltip);
+
+    if (haveContentFit) {
+        row.set_tooltip_markup(tooltip);
+    } else {
+        row.set_tooltip_markup('This feature requires Gtk 4.8 or above');
+        row.set_sensitive(false);
+    }
     prefsGroup.add(row);
 
     row.connect('notify::selected', () => {


### PR DESCRIPTION
- Disable "Fit mode" if the installed Gtk version is below 4.8. Show the explanation as well if that's the case.
- Fix `codePath`
- Add JS implementation of cubic volume → linear volume conversion as a fallback of `GstAudio`

Fix #51 