### PR TITLE
add: support for GNOME 45

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cd gnome-ext-hanabi
 
 ### Distro-specific Guides
 
-- [Installation Guide for Pop!\_OS 22.04](docs/popos-22-04.md)
+- [Installation Guide for Ubuntu/Pop!\_OS 22.04](docs/ubuntu-22-04.md)
 - [Installation Guide for Ubuntu 23.04](docs/ubuntu-23-04.md)
 
 ### Troubleshooting

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Please click on the image to view <i>(redirect to YouTube)</i>
 |   42    |   ✅   |
 |   43    |   ✅   |
 |   44    |   ✅   |
-|   45    |   🚧   |
+|   45    |   ✅   |
 
 See also the section [Troubleshooting](#troubleshooting), for version-specific known issues.
 
@@ -41,8 +41,16 @@ See also the section [Troubleshooting](#troubleshooting), for version-specific k
 
 1. Clone the repo
 
+- **For GNOME 45**
+
 ```
 git clone https://github.com/jeffshee/gnome-ext-hanabi.git
+```
+
+- **For GNOME 44 and earlier**
+
+```
+git clone https://github.com/jeffshee/gnome-ext-hanabi.git -b legacy
 ```
 
 2. Run the installation script (Require `meson`)

--- a/docs/ubuntu-22-04.md
+++ b/docs/ubuntu-22-04.md
@@ -1,4 +1,4 @@
-# Installation Guide for Pop!\_OS 22.04
+# Installation Guide for Ubuntu/Pop!\_OS 22.04
 
 _Note: Pop!\_OS has a heavily customized GNOME Shell, your mileage may vary._
 

--- a/lint/eslintrc-gjs.yml
+++ b/lint/eslintrc-gjs.yml
@@ -1,7 +1,7 @@
+# https://gitlab.gnome.org/GNOME/gnome-shell-extensions/tree/main/lint
 ---
 # SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
 # SPDX-FileCopyrightText: 2018 Claudio André <claudioandre.br@gmail.com>
-# https://gitlab.gnome.org/GNOME/gnome-shell-extensions/tree/main/lint
 
 env:
   es2021: true
@@ -70,7 +70,10 @@ rules:
   jsdoc/check-tag-names: error
   jsdoc/check-types: error
   jsdoc/implements-on-classes: error
-  jsdoc/newline-after-description: error
+  jsdoc/tag-lines:
+    - error
+    - any
+    - startLines: 1
   jsdoc/require-jsdoc: error
   jsdoc/require-param: error
   jsdoc/require-param-description: error

--- a/lint/eslintrc-shell.yml
+++ b/lint/eslintrc-shell.yml
@@ -1,4 +1,7 @@
 # https://gitlab.gnome.org/GNOME/gnome-shell-extensions/tree/main/lint
+# SPDX-FileCopyrightText: 2019 Florian Müllner <fmuellner@gnome.org>
+#
+# SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
 
 rules:
   camelcase:
@@ -12,3 +15,5 @@ rules:
   prefer-arrow-callback: error
 globals:
   global: readonly
+parserOptions:
+  sourceType: module

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   "license": "GPL-3.0-or-later",
   "devDependencies": {
     "eslint": "^8.34.0",
-    "eslint-plugin-jsdoc": "^39.8.0"
+    "eslint-plugin-jsdoc": "^46.9.0"
   }
 }

--- a/src/gnomeShellOverride.js
+++ b/src/gnomeShellOverride.js
@@ -15,60 +15,38 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/* eslint-disable no-invalid-this */
 
-/* exported GnomeShellOverride */
+import Meta from 'gi://Meta';
+import St from 'gi://St';
+import Shell from 'gi://Shell';
+import Graphene from 'gi://Graphene';
 
-const {Clutter, GLib, GObject, Meta, St, Shell, Graphene} = imports.gi;
+import {InjectionManager, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Background from 'resource:///org/gnome/shell/ui/background.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as Workspace from 'resource:///org/gnome/shell/ui/workspace.js';
+import * as WorkspaceThumbnail from 'resource:///org/gnome/shell/ui/workspaceThumbnail.js';
+import * as Util from 'resource:///org/gnome/shell/misc/util.js';
 
-const Background = imports.ui.background;
-const Main = imports.ui.main;
-const Workspace = imports.ui.workspace;
-const WorkspaceThumbnail = imports.ui.workspaceThumbnail;
-
-const ExtensionUtils = imports.misc.extensionUtils;
-const Util = imports.misc.util;
-
-const Me = ExtensionUtils.getCurrentExtension();
-const Wallpaper = Me.imports.wallpaper;
+import * as Wallpaper from './wallpaper.js';
 
 const applicationId = 'io.github.jeffshee.HanabiRenderer';
-const extSettings = ExtensionUtils.getSettings(
-    'io.github.jeffshee.hanabi-extension'
-);
 
-var replaceData = {};
-const runningWallpaperActors = new Set();
-
-/**
- * This class overrides methods in the Gnome Shell. The new methods
- * need to be defined below the class as seperate functions.
- * The old methods that are overriden can be accesed by relpacedata.old_'name-of-replaced-method'
- * in the new functions.
- */
-var GnomeShellOverride = class {
+export class GnomeShellOverride {
     constructor() {
-        this._isX11 = !Meta.is_wayland_compositor();
+        this._injectionManager = new InjectionManager();
+        this._wallpaperActors = new Set();
     }
 
     _reloadBackgrounds() {
-        runningWallpaperActors.forEach(actor => actor.destroy());
-        runningWallpaperActors.clear();
+        this._wallpaperActors.forEach(actor => actor.destroy());
+        this._wallpaperActors.clear();
 
         Main.layoutManager._updateBackgrounds();
-
-        /**
-         * Fix black lock screen background.
-         * Screen shield has its own bgManagers.
-         * We hacked background manager to add our actor before the image,
-         * but gnome-shell will disable all extensions before locking,
-         * then our player is closed, but the bgManager still holds our actor, so it gets black.
-         * Just simply re-create normal bgManagers fixed this.
-         *
-         * Also, `Main.screenShield` will be `null` when the user doesn't use gnome shell locking.
-         */
+        // `Main.screenShield` is null if the user doesn't use Gnome Shell locking.
         if (Main.screenShield?._dialog?._updateBackgrounds != null)
             Main.screenShield._dialog._updateBackgrounds();
-
 
         /**
          * WorkspaceBackground has its own bgManager,
@@ -78,218 +56,145 @@ var GnomeShellOverride = class {
     }
 
     enable() {
-        // Live wallpaper
-        this.replaceMethod(
-            Background.BackgroundManager,
-            '_createBackgroundActor',
-            new_createBackgroundActor
+        /**
+         * Live wallpaper
+         */
+        let thisRef = this;
+
+        this._injectionManager.overrideMethod(Background.BackgroundManager.prototype, '_createBackgroundActor',
+            originalMethod => {
+                return function () {
+                    const backgroundActor = originalMethod.call(this);
+
+                    // We need to pass radius to actors, so save a ref in bgManager.
+                    this.videoActor = new Wallpaper.LiveWallpaper(backgroundActor);
+                    thisRef._wallpaperActors.add(this.videoActor);
+
+                    this.videoActor.connect('destroy', actor => {
+                        thisRef._wallpaperActors.delete(actor);
+                    });
+
+                    return backgroundActor;
+                };
+            });
+
+        /**
+         * Rounded corner
+         */
+        this._injectionManager.overrideMethod(Workspace.WorkspaceBackground.prototype, '_updateBorderRadius',
+            originalMethod => {
+                return function () {
+                    originalMethod.call(this);
+
+                    const {scaleFactor} = St.ThemeContext.get_for_stage(global.stage);
+                    const cornerRadius =
+                        scaleFactor * Workspace.BACKGROUND_CORNER_RADIUS_PIXELS;
+
+                    const radius = Util.lerp(0, cornerRadius, this._stateAdjustment.value);
+                    this._bgManager.videoActor.setRoundedClipRadius(radius);
+                };
+            }
         );
 
-        // Rounded corner
-        this.replaceMethod(
-            Workspace.WorkspaceBackground,
-            '_updateBorderRadius',
-            new_updateBorderRadius
+        this._injectionManager.overrideMethod(Workspace.WorkspaceBackground.prototype, '_updateRoundedClipBounds',
+            originalMethod => {
+                return function () {
+                    originalMethod.call(this);
+
+                    const monitor = Main.layoutManager.monitors[this._monitorIndex];
+
+                    const rect = new Graphene.Rect();
+                    rect.origin.x = this._workarea.x - monitor.x;
+                    rect.origin.y = this._workarea.y - monitor.y;
+                    rect.size.width = this._workarea.width;
+                    rect.size.height = this._workarea.height;
+
+                    this._bgManager.videoActor.setRoundedClipBounds(rect);
+                };
+            }
         );
 
-        this.replaceMethod(
-            Workspace.WorkspaceBackground,
-            '_updateRoundedClipBounds',
-            new_updateRoundedClipBounds
+        /**
+         * Window hiding mechanism
+         */
+
+        // This removes the renderer from the window actor list.
+        // Call `global.get_window_actors(false)` explicitly to bypass the override.
+        this._injectionManager.overrideMethod(Shell.Global.prototype, 'get_window_actors',
+            originalMethod => {
+                // TODO: pass originalMethod to wallpaper instead
+                return function (hideRenderer = true) {
+                    let windowActors = originalMethod.call(this);
+                    let result = hideRenderer
+                        ? windowActors.filter(
+                            window => !window.meta_window.title?.includes(applicationId)
+                        )
+                        : windowActors;
+                    return result;
+                };
+            }
         );
 
-        // Hiding mechanism
-        this.replaceMethod(
-            Shell.Global,
-            'get_window_actors',
-            new_get_window_actors
+        // These remove the renderer's window preview in overview.
+        this._injectionManager.overrideMethod(Workspace.Workspace.prototype, '_isOverviewWindow',
+            originalMethod => {
+                return function (window) {
+                    let isRenderer = window.title?.includes(applicationId);
+                    return isRenderer
+                        ? false
+                        : originalMethod.apply(this, [window]);
+                };
+            }
         );
 
-        this.replaceMethod(
-            Workspace.Workspace,
-            '_isOverviewWindow',
-            new_Workspace__isOverviewWindow,
-            'Workspace'
+        this._injectionManager.overrideMethod(WorkspaceThumbnail.WorkspaceThumbnail.prototype, '_isOverviewWindow',
+            originalMethod => {
+                return function (window) {
+                    let isRenderer = window.title?.includes(applicationId);
+                    return isRenderer
+                        ? false
+                        : originalMethod.apply(this, [window]);
+                };
+            }
         );
 
-        this.replaceMethod(
-            WorkspaceThumbnail.WorkspaceThumbnail,
-            '_isOverviewWindow',
-            new_WorkspaceThumbnail__isOverviewWindow,
-            'WorkspaceThumbnail'
+        // This remove the renderer icon from altTab and ctrlAltTab(?).
+        this._injectionManager.overrideMethod(Meta.Display.prototype, 'get_tab_list',
+            originalMethod => {
+                return function (type, workspace) {
+                    let metaWindows = originalMethod.apply(this, [
+                        type,
+                        workspace,
+                    ]);
+                    let result = metaWindows.filter(
+                        metaWindow => !metaWindow.title?.includes(applicationId)
+                    );
+                    return result;
+                };
+            }
         );
 
-        this.replaceMethod(Meta.Display, 'get_tab_list', new_get_tab_list);
-
-        this.replaceMethod(Shell.AppSystem, 'get_running', new_get_running);
+        // This remove the renderer icon from altTab and dash.
+        this._injectionManager.overrideMethod(Shell.AppSystem.prototype, 'get_running',
+            originalMethod => {
+                return function () {
+                    let runningApps = originalMethod.call(this);
+                    let result = runningApps.filter(
+                        app =>
+                            !app
+                            .get_windows()
+                            .some(window => window.title?.includes(applicationId))
+                    );
+                    return result;
+                };
+            }
+        );
 
         this._reloadBackgrounds();
     }
 
     disable() {
-        for (let value of Object.values(replaceData)) {
-            if (value[0])
-                value[1].prototype[value[2]] = value[0];
-        }
-
-        replaceData = {};
-
+        this._injectionManager.clear();
         this._reloadBackgrounds();
     }
-
-    /**
-     * Replaces a method in a class with our own method, and stores the original
-     * one in 'replaceData' using 'old_XXXX' (being XXXX the name of the original method),
-     * or 'old_classId_XXXX' if 'classId' is defined. This is done this way for the
-     * case that two methods with the same name must be replaced in two different
-     * classes
-     *
-     * @param {class} className The class where to replace the method
-     * @param {string} methodName The method to replace
-     * @param {Function} functionToCall The function to call as the replaced method
-     * @param {string} [classId] an extra ID to identify the stored method when two
-     *                           methods with the same name are replaced in
-     *                           two different classes
-     */
-    replaceMethod(className, methodName, functionToCall, classId) {
-        if (classId) {
-            replaceData[`old_${classId}_${methodName}`] = [
-                className.prototype[methodName],
-                className,
-                methodName,
-                classId,
-            ];
-        } else {
-            replaceData[`old_${methodName}`] = [
-                className.prototype[methodName],
-                className,
-                methodName,
-            ];
-        }
-        className.prototype[methodName] = functionToCall;
-    }
-};
-
-/**
- * New functions used to replace the gnome shell functions are defined below.
- */
-
-/**
- * This creates the LiveWallpaper widget.
- */
-function new_createBackgroundActor() {
-    const backgroundActor =
-        replaceData.old__createBackgroundActor[0].call(this);
-    // We need to pass radius to actors, so save a ref in bgManager.
-    this.videoActor = new Wallpaper.LiveWallpaper(backgroundActor);
-    runningWallpaperActors.add(this.videoActor);
-    this.videoActor.connect('destroy', actor => {
-        runningWallpaperActors.delete(actor);
-    });
-    return backgroundActor;
-}
-
-/**
- * This removes the renderer from the window actor list.
- * Use `false` as the argument to bypass this behavior.
- *
- * @param hideRenderer
- */
-function new_get_window_actors(hideRenderer = true) {
-    let windowActors = replaceData.old_get_window_actors[0].call(this);
-    let result = hideRenderer
-        ? windowActors.filter(
-            window => !window.meta_window.title?.includes(applicationId)
-        )
-        : windowActors;
-    return result;
-}
-
-/**
- * These remove the renderer's window preview in overview.
- *
- * @param window
- */
-function new_Workspace__isOverviewWindow(window) {
-    let isRenderer = window.title?.includes(applicationId);
-    return isRenderer
-        ? false
-        : replaceData.old_Workspace__isOverviewWindow[0].apply(this, [window]);
-}
-
-/**
- *
- * @param window
- */
-function new_WorkspaceThumbnail__isOverviewWindow(window) {
-    let isRenderer = window.title?.includes(applicationId);
-    return isRenderer
-        ? false
-        : replaceData.old_WorkspaceThumbnail__isOverviewWindow[0].apply(this, [
-            window,
-        ]);
-}
-
-/**
- * This remove the renderer icon from altTab and ctrlAltTab(?).
- *
- * @param type
- * @param workspace
- */
-function new_get_tab_list(type, workspace) {
-    let metaWindows = replaceData.old_get_tab_list[0].apply(this, [
-        type,
-        workspace,
-    ]);
-    let result = metaWindows.filter(
-        metaWindow => !metaWindow.title?.includes(applicationId)
-    );
-    return result;
-}
-
-/**
- * This remove the renderer icon from altTab and dash.
- */
-function new_get_running() {
-    let runningApps = replaceData.old_get_running[0].call(this);
-    let result = runningApps.filter(
-        app =>
-            !app
-                .get_windows()
-                .some(window => window.title?.includes(applicationId))
-    );
-    return result;
-}
-
-/**
- * WorkspaceBackground has its own bgManager, the rounded corner is made by
- * passing value to MetaBackgroundContent, we don't have content, but could do
- * the same to actor.
- */
-function new_updateBorderRadius() {
-    replaceData.old__updateBorderRadius[0].call(this);
-
-    const {scaleFactor} = St.ThemeContext.get_for_stage(global.stage);
-    const cornerRadius =
-        scaleFactor * Workspace.BACKGROUND_CORNER_RADIUS_PIXELS;
-
-    const radius = Util.lerp(0, cornerRadius, this._stateAdjustment.value);
-    this._bgManager.videoActor.setRoundedClipRadius(radius);
-}
-
-/**
- *
- */
-function new_updateRoundedClipBounds() {
-    replaceData.old__updateRoundedClipBounds[0].call(this);
-
-    const monitor = Main.layoutManager.monitors[this._monitorIndex];
-
-    const rect = new Graphene.Rect();
-    rect.origin.x = this._workarea.x - monitor.x;
-    rect.origin.y = this._workarea.y - monitor.y;
-    rect.size.width = this._workarea.width;
-    rect.size.height = this._workarea.height;
-
-    this._bgManager.videoActor.setRoundedClipBounds(rect);
 }

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -21,23 +21,17 @@
  * LaunchSubprocess in the DING extension.
  */
 
-/* exported LaunchSubprocess */
+import Meta from 'gi://Meta';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 
-const {Meta, Gio, GLib, St} = imports.gi;
-
-const Config = imports.misc.config;
-const ExtensionUtils = imports.misc.extensionUtils;
-
-const Me = ExtensionUtils.getCurrentExtension();
-const Logger = Me.imports.logger;
+import * as Logger from './logger.js';
 
 const logger = new Logger.Logger();
 const rendererLogger = new Logger.Logger('renderer');
 
-
-var LaunchSubprocess = class {
+export class LaunchSubprocess {
     constructor(flags = Gio.SubprocessFlags.NONE) {
-        this._gnomeShellVersion = parseInt(Config.PACKAGE_VERSION.split('.')[0]);
         this._isX11 = !Meta.is_wayland_compositor();
 
         this._flags =
@@ -48,7 +42,7 @@ var LaunchSubprocess = class {
         this.cancellable = new Gio.Cancellable();
         this._launcher = new Gio.SubprocessLauncher({flags: this._flags});
         if (!this._isX11)
-            this._waylandClient = this._gnomeShellVersion > 43 ? Meta.WaylandClient.new(global.context, this._launcher) : Meta.WaylandClient.new(this._launcher);
+            this._waylandClient = Meta.WaylandClient.new(global.context, this._launcher);
 
         this.subprocess = null;
         this.running = false;
@@ -145,4 +139,4 @@ var LaunchSubprocess = class {
         if (!this._isX11 && this.running)
             this._waylandClient.hide_from_window_list(window);
     }
-};
+}

--- a/src/logger.js
+++ b/src/logger.js
@@ -15,26 +15,23 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import Gio from 'gi://Gio';
 
-/* exported Logger */
+const schemaId = 'io.github.jeffshee.hanabi-extension';
+const logPrefix = 'Hanabi:';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-
-var Logger = class Logger {
+export class Logger {
     constructor(opt = undefined) {
-        const extSchemaId = 'io.github.jeffshee.hanabi-extension';
-        const debugModeKey = 'debug-mode';
-        const extSettings = ExtensionUtils.getSettings(extSchemaId);
-        const logPrefix = 'Hanabi:';
+        const settingsSchemaSource = Gio.SettingsSchemaSource.get_default();
+        if (settingsSchemaSource.lookup(schemaId, false))
+            this._settings = Gio.Settings.new(schemaId);
 
         this.logPrefix = logPrefix;
         this.logOpt = opt;
-        this.isDebugMode = extSettings ? extSettings.get_boolean(debugModeKey) : false;
+        this.isDebugMode = this._settings ? this._settings.get_boolean('debug-mode') : false;
 
-        extSettings?.connect('changed', (settings, key) => {
-            if (key === debugModeKey)
-                this.isDebugMode = settings.get_boolean(debugModeKey);
+        this._settings?.connect('changed::debug-mode', () => {
+            this.isDebugMode = this._settings.get_boolean('debug-mode');
         });
     }
 
@@ -71,4 +68,4 @@ var Logger = class Logger {
     trace(...args) {
         console.trace(...this._processArgs(args));
     }
-};
+}

--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -1,11 +1,10 @@
 {
   "description": "Live Wallpaper for GNOME\n\nHanabi 花火【はなび】(n) fireworks\n( ・ω・)o─━・*:'・:・゜'・:※",
+  "gettext-domain": "@uuid@",
   "name": "Hanabi Extension",
   "settings-schema": "@settings_schema@",
   "shell-version": [
-    "42",
-    "43",
-    "44"
+    "45"
   ],
   "url": "https://github.com/jeffshee/gnome-ext-hanabi",
   "uuid": "@uuid@",

--- a/src/panelMenu.js
+++ b/src/panelMenu.js
@@ -15,36 +15,21 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/* exported PanelMenu */
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import St from 'gi://St';
 
-const {Gio, GLib, St} = imports.gi;
-const Gettext = imports.gettext;
+import {gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
-const Main = imports.ui.main;
-const PanelMenu = imports.ui.panelMenu;
-const PopupMenu = imports.ui.popupMenu;
+export class HanabiPanelMenu {
+    constructor(extension) {
+        this.isEnabled = false;
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-
-const extSettings = ExtensionUtils.getSettings(
-    'io.github.jeffshee.hanabi-extension'
-);
-
-const Domain = Gettext.domain(Me.metadata.uuid);
-const _ = Domain.gettext;
-const ngettext = Domain.ngettext;
-
-const getMute = () => {
-    return extSettings.get_boolean('mute');
-};
-
-const setMute = mute => {
-    return extSettings.set_boolean('mute', mute);
-};
-
-var HanabiPanelMenu = class HanabiPanelMenu {
-    constructor() {
+        this._extension = extension;
+        this._settings = extension.getSettings();
         this._isPlaying = false;
 
         // DBus
@@ -65,13 +50,16 @@ var HanabiPanelMenu = class HanabiPanelMenu {
     }
 
     enable() {
+        if (this.isEnabled)
+            return;
+
         // Indicator
-        const indicatorName = `${Me.metadata.name} Indicator`;
+        const indicatorName = `${this._extension.metadata.name} Indicator`;
         this.indicator = new PanelMenu.Button(0.0, indicatorName, false);
         const icon = new St.Icon({
             gicon: Gio.icon_new_for_string(
                 GLib.build_filenamev([
-                    ExtensionUtils.getCurrentExtension().path,
+                    this._extension.path,
                     'hanabi-symbolic.svg',
                 ])
             ),
@@ -89,7 +77,7 @@ var HanabiPanelMenu = class HanabiPanelMenu {
 
         Main.panel.addToStatusArea(indicatorName, this.indicator);
 
-        // PlayPause
+        // Play Pause
         const playPause = new PopupMenu.PopupMenuItem(
             this._isPlaying ? _('Pause') : _('Play')
         );
@@ -118,32 +106,45 @@ var HanabiPanelMenu = class HanabiPanelMenu {
 
         menu.addMenuItem(playPause);
 
-        // MuteUnmute
+        // Mute Unmute
         const muteAudio = new PopupMenu.PopupMenuItem(
-            getMute() ? _('Unmute Audio') : _('Mute Audio')
+            this._getMute() ? _('Unmute Audio') : _('Mute Audio')
         );
 
         muteAudio.connect('activate', () => {
-            setMute(!getMute());
+            this._setMute(!this._getMute());
         });
 
-        extSettings?.connect('changed', (settings, key) => {
-            if (key === 'mute') {
-                muteAudio.label.set_text(
-                    getMute() ? _('Unmute Audio') : _('Mute Audio')
-                );
-            }
+        this._settings.connect('changed::mute', () => {
+            muteAudio.label.set_text(
+                this._getMute() ? _('Unmute Audio') : _('Mute Audio')
+            );
         });
 
         menu.addMenuItem(muteAudio);
 
         // Preferences
         menu.addAction(_('Preferences'), () => {
-            ExtensionUtils.openPrefs();
+            this._extension.openPreferences();
         });
+
+        this.isEnabled = true;
     }
 
-    disable() {
-        this.indicator.destroy();
+    _getMute() {
+        this._settings.get_boolean('mute');
     }
-};
+
+    _setMute(mute) {
+        this._settings.set_boolean('mute', mute);
+    }
+
+
+    disable() {
+        if (!this.isEnabled)
+            return;
+
+        this.indicator.destroy();
+        this.isEnabled = false;
+    }
+}

--- a/src/panelMenu.js
+++ b/src/panelMenu.js
@@ -132,11 +132,11 @@ export class HanabiPanelMenu {
     }
 
     _getMute() {
-        this._settings.get_boolean('mute');
+        return this._settings.get_boolean('mute');
     }
 
     _setMute(mute) {
-        this._settings.set_boolean('mute', mute);
+        return this._settings.set_boolean('mute', mute);
     }
 
 

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -18,8 +18,7 @@
  */
 
 imports.gi.versions.Gtk = '4.0';
-imports.gi.versions.GdkX11 = '4.0';
-const {GObject, Gtk, Gio, GLib, Gdk, GdkX11, Gst} = imports.gi;
+const {GObject, Gtk, Gio, GLib, Gdk, Gst} = imports.gi;
 
 let GstPlay = null;
 // GstPlay is available from GStreamer 1.20+

--- a/src/roundedCornersEffect.js
+++ b/src/roundedCornersEffect.js
@@ -16,9 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/* exported RoundedCornersEffect */
-
-const {GObject, Shell} = imports.gi;
+import GObject from 'gi://GObject';
+import Shell from 'gi://Shell';
 
 // This shader is copied from Mutter project.
 // See <https://gitlab.gnome.org/GNOME/mutter/-/blob/main/src/compositor/meta-background-content.c>.
@@ -69,6 +68,7 @@ const fragmentShaderDeclarations = [
     '  return outer_radius - sqrt (dist_squared);                             \n',
     '}                                                                        \n',
 ].join('');
+
 const fragmentShaderCode = [
     'vec2 texture_coord;                                                      \n',
     '                                                                         \n',
@@ -78,9 +78,7 @@ const fragmentShaderCode = [
 ].join('');
 
 // A naive pipeline that just updates uniforms.
-// TODO: It should be better if we save input value and check whether they are
-// the same with previous values before passing into shaders.
-var RoundedCornersEffect = GObject.registerClass(
+export const RoundedCornersEffect = GObject.registerClass(
     class RoundedCornersEffect extends Shell.GLSLEffect {
         vfunc_build_pipeline() {
             this.add_glsl_snippet(

--- a/src/wallpaper.js
+++ b/src/wallpaper.js
@@ -15,31 +15,26 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import Meta from 'gi://Meta';
+import St from 'gi://St';
+import Graphene from 'gi://Graphene';
 
-/* exported LiveWallpaper */
+import * as Background from 'resource:///org/gnome/shell/ui/background.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
-const {Clutter, GLib, GObject, Meta, St, Shell, Graphene} = imports.gi;
-
-const Background = imports.ui.background;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Main = imports.ui.main;
-const Workspace = imports.ui.workspace;
-const WorkspaceThumbnail = imports.ui.workspaceThumbnail;
-
-const Me = ExtensionUtils.getCurrentExtension();
-const RoundedCornersEffect = Me.imports.roundedCornersEffect;
-const Logger = Me.imports.logger;
+import * as Logger from './logger.js';
+import * as RoundedCornersEffect from './roundedCornersEffect.js';
 
 const applicationId = 'io.github.jeffshee.HanabiRenderer';
-const extSettings = ExtensionUtils.getSettings(
-    'io.github.jeffshee.hanabi-extension'
-);
 const logger = new Logger.Logger();
 
 /**
  * The widget that holds the window preview of the renderer.
  */
-var LiveWallpaper = GObject.registerClass(
+export const LiveWallpaper = GObject.registerClass(
     class LiveWallpaper extends St.Widget {
         constructor(backgroundActor) {
             super({
@@ -52,7 +47,7 @@ var LiveWallpaper = GObject.registerClass(
                 // Layout manager will allocate extra space for the actor, if possible.
                 x_expand: true,
                 y_expand: true,
-                // backgroundActor's z_position is 0. Positive values = nearer to the user.
+                // Larger value = nearer to the user.
                 z_position: backgroundActor.z_position + 1,
                 opacity: 0,
             });
@@ -85,14 +80,6 @@ var LiveWallpaper = GObject.registerClass(
             rect.size.width = this._monitorWidth;
             rect.size.height = this._monitorHeight;
             this.setRoundedClipBounds(rect);
-            // TODO: Not sure if monitorScale is needed.
-            // What is this? Well, OpenGL texture coordinates are [0.0, 1.0],
-            // but we do bound and radius calculation with pixels, so we need a
-            // way to convert coordinates into pixels.
-            // NOTE: I currently don't know why, but I need monitor width and
-            // height here, not actor width and height, one reason maybe that
-            // our actor actually takes the whole screen and we use monitor
-            // width and height in the bound rect.
             this._roundedCornersEffect.setPixelStep([
                 1.0 / this._monitorWidth,
                 1.0 / this._monitorHeight,
@@ -112,9 +99,7 @@ var LiveWallpaper = GObject.registerClass(
                     rect.origin.y,
                     rect.origin.x + rect.size.width,
                     rect.origin.y + rect.size.height,
-                ].map(e => {
-                    return e * this._monitorScale;
-                })
+                ].map(e => e * this._monitorScale)
             );
         }
 

--- a/src/wallpaper.js
+++ b/src/wallpaper.js
@@ -108,13 +108,6 @@ export const LiveWallpaper = GObject.registerClass(
             const operation = () => {
                 const renderer = this._getRenderer();
                 if (renderer) {
-                    // TODO: WIP MetaSurfaceContainerActorWayland bug workaround
-                    let surfaceContainer = renderer.get_children().find(
-                        child => GObject.type_name(child) === 'MetaSurfaceContainerActorWayland'
-                    );
-                    if (surfaceContainer)
-                        surfaceContainer.set_position(0, 0);
-
                     this._wallpaper = new Clutter.Clone({
                         source: renderer,
                         // The point around which the scaling and rotation transformations occur.

--- a/src/wallpaper.js
+++ b/src/wallpaper.js
@@ -108,6 +108,13 @@ export const LiveWallpaper = GObject.registerClass(
             const operation = () => {
                 const renderer = this._getRenderer();
                 if (renderer) {
+                    // TODO: WIP MetaSurfaceContainerActorWayland bug workaround
+                    let surfaceContainer = renderer.get_children().find(
+                        child => GObject.type_name(child) === 'MetaSurfaceContainerActorWayland'
+                    );
+                    if (surfaceContainer)
+                        surfaceContainer.set_position(0, 0);
+
                     this._wallpaper = new Clutter.Clone({
                         source: renderer,
                         // The point around which the scaling and rotation transformations occur.

--- a/src/windowManager.js
+++ b/src/windowManager.js
@@ -21,14 +21,9 @@
  * ManageWindow and EmulateX11WindowType in the DING extension.
  */
 
-/* exported WindowManager */
+import Meta from 'gi://Meta';
 
-const {GLib, Meta} = imports.gi;
-const Main = imports.ui.main;
-const ExtensionUtils = imports.misc.extensionUtils;
-
-const Me = ExtensionUtils.getCurrentExtension();
-const Logger = Me.imports.logger;
+import * as Logger from './logger.js';
 
 const applicationId = 'io.github.jeffshee.HanabiRenderer';
 const logger = new Logger.Logger();
@@ -126,7 +121,7 @@ class ManagedWindow {
     }
 }
 
-var WindowManager = class {
+export class WindowManager {
     constructor() {
         this._isX11 = !Meta.is_wayland_compositor();
         this._windows = new Set();
@@ -188,4 +183,4 @@ var WindowManager = class {
         window.managed.disconnect();
         window.managed = null;
     }
-};
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,14 @@
 # yarn lockfile v1
 
 
-"@es-joy/jsdoccomment@~0.36.1":
-  version "0.36.1"
-  resolved "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz"
-  integrity sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==
+"@es-joy/jsdoccomment@~0.41.0":
+  version "0.41.0"
+  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.41.0.tgz#4a2f7db42209c0425c71a1476ef1bdb6dcd836f6"
+  integrity sha512-aKUhyn1QI5Ksbqcr3fFJj16p99QdjUxXAEuFst1Z47DRyoiMwivIH9MV/ARcJOCXVjPfjITciej8ZD2O/6qUmw==
   dependencies:
-    comment-parser "1.3.1"
-    esquery "^1.4.0"
-    jsdoc-type-pratt-parser "~3.1.0"
+    comment-parser "1.4.1"
+    esquery "^1.5.0"
+    jsdoc-type-pratt-parser "~4.0.0"
 
 "@eslint/eslintrc@^1.4.1":
   version "1.4.1"
@@ -71,7 +71,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.8.0:
+acorn@^8.8.0:
   version "8.8.2"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
@@ -98,6 +98,11 @@ ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+are-docs-informative@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/are-docs-informative/-/are-docs-informative-0.0.2.tgz#387f0e93f5d45280373d387a59d34c96db321963"
+  integrity sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==
+
 argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
@@ -115,6 +120,11 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+builtin-modules@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
+  integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -141,10 +151,10 @@ color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-comment-parser@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz"
-  integrity sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==
+comment-parser@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.4.1.tgz#bdafead37961ac079be11eb7ec65c4d021eaf9cc"
+  integrity sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -184,17 +194,19 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-plugin-jsdoc@^39.8.0:
-  version "39.8.0"
-  resolved "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.8.0.tgz"
-  integrity sha512-ZwGmk0jJoJD/NILeDRBKrpq/PCgddUdATjeU5JGTqTzKsOWfeaHOnaAwZjuOh7T8EB4hSoZ/9pR4+Qns2ldQVg==
+eslint-plugin-jsdoc@^46.9.0:
+  version "46.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.9.0.tgz#9887569dbeef0a008a2770bfc5d0f7fc39f21f2b"
+  integrity sha512-UQuEtbqLNkPf5Nr/6PPRCtr9xypXY+g8y/Q7gPa0YK7eDhh0y2lWprXRnaYbW7ACgIUvpDKy9X2bZqxtGzBG9Q==
   dependencies:
-    "@es-joy/jsdoccomment" "~0.36.1"
-    comment-parser "1.3.1"
+    "@es-joy/jsdoccomment" "~0.41.0"
+    are-docs-informative "^0.0.2"
+    comment-parser "1.4.1"
     debug "^4.3.4"
     escape-string-regexp "^4.0.0"
-    esquery "^1.4.0"
-    semver "^7.3.8"
+    esquery "^1.5.0"
+    is-builtin-module "^3.2.1"
+    semver "^7.5.4"
     spdx-expression-parse "^3.0.1"
 
 eslint-scope@^7.1.1:
@@ -222,7 +234,7 @@ eslint-visitor-keys@^3.3.0:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
-"eslint@^7.0.0 || ^8.0.0", eslint@^8.34.0, eslint@>=5:
+eslint@^8.34.0:
   version "8.34.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.34.0.tgz"
   integrity sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==
@@ -280,6 +292,13 @@ esquery@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz"
   integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
+  dependencies:
+    estraverse "^5.1.0"
+
+esquery@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
+  integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
   dependencies:
     estraverse "^5.1.0"
 
@@ -422,6 +441,13 @@ inherits@2:
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+is-builtin-module@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.1.tgz#f03271717d8654cfcaf07ab0463faa3571581169"
+  integrity sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==
+  dependencies:
+    builtin-modules "^3.3.0"
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
@@ -456,10 +482,10 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-jsdoc-type-pratt-parser@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz"
-  integrity sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==
+jsdoc-type-pratt-parser@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz#136f0571a99c184d84ec84662c45c29ceff71114"
+  integrity sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -614,10 +640,10 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-semver@^7.3.8:
-  version "7.3.8"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+semver@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
Hanabi seems to work without any big issues in GNOME 45.
After merging the `gnome-45` to `master`, users who want to install Hanabi for GNOME 44 and earlier will be required to use the `legacy` branch, as mentioned in the README.

close #81, close #98
 