### PR TITLE
Feature: Implement Automatic Wallpaper Changer (Legacy)

### DIFF
--- a/src/panelMenu.js
+++ b/src/panelMenu.js
@@ -55,6 +55,10 @@ const setNextWallpaper = () => {
     let changeWallpaperDirectoryPath = extSettings.get_string('change-wallpaper-directory-path');
     let videoPaths = [];
     let dir = Gio.File.new_for_path(changeWallpaperDirectoryPath);
+    // Check if dir exists and is a directory
+    if (dir.query_file_type(Gio.FileQueryInfoFlags.NONE, null) !== Gio.FileType.DIRECTORY)
+        return;
+
     let enumerator = dir.enumerate_children(
         'standard::*',
         Gio.FileQueryInfoFlags.NONE,
@@ -181,7 +185,7 @@ var HanabiPanelMenu = class HanabiPanelMenu {
         if (!getChangeWallpaper())
             nextWallpaperMenuItem.hide();
 
-        extSettings?.connect('changed::change-wallpaper', (settings, key) => {
+        extSettings?.connect('changed::change-wallpaper', () => {
             if (getChangeWallpaper())
                 nextWallpaperMenuItem.show();
             else

--- a/src/panelMenu.js
+++ b/src/panelMenu.js
@@ -48,10 +48,11 @@ const getChangeWallpaper = () => {
 };
 
 /**
- * 
+ *
  * Set next wallpaper based in directory.
  */
 const setNextWallpaper = () => {
+    let changeWallpaperDirectoryPath = extSettings.get_string('change-wallpaper-directory-path');
     let videoPaths = [];
     let dir = Gio.File.new_for_path(changeWallpaperDirectoryPath);
     let enumerator = dir.enumerate_children(

--- a/src/po/cs.po
+++ b/src/po/cs.po
@@ -22,7 +22,7 @@ msgstr ""
 msgid "General"
 msgstr "Obecné"
 
-#: src/prefs.js:53 src/panelMenu.js:121 src/panelMenu.js:131
+#: src/prefs.js:53 src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Mute Audio"
 msgstr "Vypnout zvuk"
 
@@ -34,60 +34,68 @@ msgstr "Hlasitost"
 msgid "Show Panel Menu"
 msgstr "Zobrazit menu na panelu"
 
-#: src/prefs.js:58
+#: src/prefs.js:56
+msgid "Change Wallpaper Automatically"
+msgstr ""
+
+#: src/prefs.js:59
+msgid "Change Wallpaper Interval (minutes)"
+msgstr ""
+
+#: src/prefs.js:62
 msgid "Experimental"
 msgstr "Experimentální"
 
-#: src/prefs.js:63
+#: src/prefs.js:67
 msgid "Experimental VA Plugin"
 msgstr "Experimentální VA Plugin"
 
-#: src/prefs.js:65
+#: src/prefs.js:69
 msgid ""
 "Enable VA decoders which improve performance for Intel/AMD Wayland users"
 msgstr "Povolit VA dekodéry které zlepší výkon pro Intel/AMD Wayland uživatele"
 
-#: src/prefs.js:69
+#: src/prefs.js:73
 msgid "NVIDIA Stateless Decoders"
 msgstr "NVIDIA Stateless Dekodéry"
 
-#: src/prefs.js:71
+#: src/prefs.js:75
 msgid "Use new stateless NVIDIA decoders"
 msgstr "Použít nové stateless NVIDIA dekodéry"
 
-#: src/prefs.js:74
+#: src/prefs.js:78
 msgid "Developer"
 msgstr "Pro vývojáře"
 
-#: src/prefs.js:78
+#: src/prefs.js:82
 msgid "Debug Mode"
 msgstr "Debug mód"
 
-#: src/prefs.js:80
+#: src/prefs.js:84
 msgid "Print debug messages to log"
 msgstr "Vypisovat ladící zprávy do protokolu"
 
-#: src/prefs.js:84
+#: src/prefs.js:88
 msgid "Force gtk4paintablesink"
 msgstr "Vynutit gtk4paintablesink"
 
-#: src/prefs.js:86
+#: src/prefs.js:90
 msgid "Force use of gtk4paintablesink for video playback"
 msgstr "Vynutí použití gtk4paintablesink pro přehrávání videa"
 
-#: src/prefs.js:90
+#: src/prefs.js:94
 msgid "Force GtkMediaFile"
 msgstr "Vynutit GtkMediaFile"
 
-#: src/prefs.js:92
+#: src/prefs.js:96
 msgid "Force use of GtkMediaFile for video playback"
 msgstr "Vynutí použití GtkMediaFile pro přehrávání videa"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid "Startup Delay"
 msgstr "Prodleva při startu"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid ""
 "Add a startup delay (in milliseconds) to mitigate compatibility issues with "
 "other extensions"
@@ -95,35 +103,43 @@ msgstr ""
 "Přidá časovou prodlevu (v milisekundách) před startem, aby se vyhnulo "
 "potížím s kompatibilitou s ostatními rozšířeními"
 
-#: src/prefs.js:174
+#: src/prefs.js:178
 msgid "Video Path"
 msgstr "Cesta k videu"
 
-#: src/prefs.js:180 src/prefs.js:205
+#: src/prefs.js:184 src/prefs.js:209 src/prefs.js:242 src/prefs.js:263
 msgid "None"
 msgstr "Žádné video"
 
-#: src/prefs.js:192
+#: src/prefs.js:196
 msgid "Open File"
 msgstr "Otevřít soubor"
 
-#: src/prefs.js:197
+#: src/prefs.js:201 src/prefs.js:256
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: src/prefs.js:198 src/prefs.js:214
+#: src/prefs.js:202 src/prefs.js:218 src/prefs.js:257 src/prefs.js:272
 msgid "Open"
 msgstr "Otevřít"
 
-#: src/prefs.js:231
+#: src/prefs.js:236
+msgid "Change Wallpaper Directory Path"
+msgstr ""
+
+#: src/prefs.js:251
+msgid "Select Directory"
+msgstr ""
+
+#: src/prefs.js:289
 msgid "Fit Mode"
 msgstr "Mód vyplnění"
 
-#: src/prefs.js:232
+#: src/prefs.js:290
 msgid "Control how wallpaper fits within the monitor"
 msgstr "Nastavit jak se pozadí vejde do obrazovky"
 
-#: src/prefs.js:233
+#: src/prefs.js:291
 msgid ""
 "\n"
 "    <b>Fill</b>: Stretch the wallpaper to fill the monitor.\n"
@@ -145,38 +161,72 @@ msgstr ""
 "třeba, jinak ponechat v původní velikosti\n"
 "    "
 
-#: src/prefs.js:241
+#: src/prefs.js:299
 msgid "Fill"
 msgstr "Roztáhnout"
 
-#: src/prefs.js:242
+#: src/prefs.js:300
 msgid "Contain"
 msgstr "Obsáhnout"
 
-#: src/prefs.js:243
+#: src/prefs.js:301
 msgid "Cover"
 msgstr "Vyplnit"
 
-#: src/prefs.js:244
+#: src/prefs.js:302
 msgid "Scale-down"
 msgstr "Škálovat dolů"
 
-#: src/prefs.js:257
+#: src/prefs.js:315
 msgid "This feature requires Gtk 4.8 or above"
 msgstr "Tato funkce požaduje Gtk 4.8 nebo novější"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/prefs.js:330
+msgid "Change Wallpaper Mode"
+msgstr ""
+
+#: src/prefs.js:331
+msgid "Control how to change wallpapers automatically"
+msgstr ""
+
+#: src/prefs.js:332
+msgid ""
+"\n"
+"    <b>Sequential:</b> Preserve the directory sequence (descending order).\n"
+"    <b>Inverse Sequential:</b> Retrieve wallpapers in the opposite sequence "
+"(ascending order).\n"
+"    <b>Random:</b> Randomly select wallpapers from the directory.\n"
+"    "
+msgstr ""
+
+#: src/prefs.js:339
+msgid "Sequential"
+msgstr ""
+
+#: src/prefs.js:340
+msgid "Inverse Sequential"
+msgstr ""
+
+#: src/prefs.js:341
+msgid "Random"
+msgstr ""
+
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Pause"
 msgstr "Pozastavit"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Play"
 msgstr "Přehrát"
 
-#: src/panelMenu.js:121 src/panelMenu.js:131
+#: src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Unmute Audio"
 msgstr "Zapnout zvuk"
 
-#: src/panelMenu.js:139
+#: src/panelMenu.js:187 src/panelMenu.js:195
+msgid "Next Wallpaper"
+msgstr ""
+
+#: src/panelMenu.js:206
 msgid "Preferences"
 msgstr "Nastavení"

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -21,7 +21,7 @@ msgstr ""
 msgid "General"
 msgstr "Allgemein"
 
-#: src/prefs.js:53 src/panelMenu.js:121 src/panelMenu.js:131
+#: src/prefs.js:53 src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Mute Audio"
 msgstr "Ton stummschalten"
 
@@ -33,62 +33,70 @@ msgstr "Ausgabelautstärke"
 msgid "Show Panel Menu"
 msgstr "Panel Menü anzeigen"
 
-#: src/prefs.js:58
+#: src/prefs.js:56
+msgid "Change Wallpaper Automatically"
+msgstr ""
+
+#: src/prefs.js:59
+msgid "Change Wallpaper Interval (minutes)"
+msgstr ""
+
+#: src/prefs.js:62
 msgid "Experimental"
 msgstr "Experimentell"
 
-#: src/prefs.js:63
+#: src/prefs.js:67
 msgid "Experimental VA Plugin"
 msgstr "Experimentelles VA Plugin"
 
-#: src/prefs.js:65
+#: src/prefs.js:69
 msgid ""
 "Enable VA decoders which improve performance for Intel/AMD Wayland users"
 msgstr ""
 "Aktivierung von VA Dekodierern, welche die Leistung für Intel/AMD Wayland "
 "Benutzer verbessern"
 
-#: src/prefs.js:69
+#: src/prefs.js:73
 msgid "NVIDIA Stateless Decoders"
 msgstr "NVIDIA Stateless Dekodierer"
 
-#: src/prefs.js:71
+#: src/prefs.js:75
 msgid "Use new stateless NVIDIA decoders"
 msgstr "Benutze neue NVIDIA stateless Dekodierer"
 
-#: src/prefs.js:74
+#: src/prefs.js:78
 msgid "Developer"
 msgstr "Entwickler"
 
-#: src/prefs.js:78
+#: src/prefs.js:82
 msgid "Debug Mode"
 msgstr "Debug Modus"
 
-#: src/prefs.js:80
+#: src/prefs.js:84
 msgid "Print debug messages to log"
 msgstr "Schreibt Debug Nachrichten in das Protokoll"
 
-#: src/prefs.js:84
+#: src/prefs.js:88
 msgid "Force gtk4paintablesink"
 msgstr "Erzwinge gtk4paintablesink"
 
-#: src/prefs.js:86
+#: src/prefs.js:90
 msgid "Force use of gtk4paintablesink for video playback"
 msgstr "Verwendung von gtk4paintablesink für die Videowiedergabe erzwingen"
 
-#: src/prefs.js:90
+#: src/prefs.js:94
 msgid "Force GtkMediaFile"
 msgstr "Erzwinge GtkMediaFile"
 
-#: src/prefs.js:92
+#: src/prefs.js:96
 msgid "Force use of GtkMediaFile for video playback"
 msgstr "Verwendung von GtkMediaFile für die Videowiedergabe erzwingen"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid "Startup Delay"
 msgstr "Startverzögerung"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid ""
 "Add a startup delay (in milliseconds) to mitigate compatibility issues with "
 "other extensions"
@@ -96,35 +104,43 @@ msgstr ""
 "Fügt eine Startverzögerung (in Millisekunden) hinzu, um "
 "Kompatibilitätsprobleme mit anderen Erweiterungen zu verringern"
 
-#: src/prefs.js:174
+#: src/prefs.js:178
 msgid "Video Path"
 msgstr "Videopfad"
 
-#: src/prefs.js:180 src/prefs.js:205
+#: src/prefs.js:184 src/prefs.js:209 src/prefs.js:242 src/prefs.js:263
 msgid "None"
 msgstr "Keiner"
 
-#: src/prefs.js:192
+#: src/prefs.js:196
 msgid "Open File"
 msgstr "Öffne Datei"
 
-#: src/prefs.js:197
+#: src/prefs.js:201 src/prefs.js:256
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/prefs.js:198 src/prefs.js:214
+#: src/prefs.js:202 src/prefs.js:218 src/prefs.js:257 src/prefs.js:272
 msgid "Open"
 msgstr "Öffnen"
 
-#: src/prefs.js:231
+#: src/prefs.js:236
+msgid "Change Wallpaper Directory Path"
+msgstr ""
+
+#: src/prefs.js:251
+msgid "Select Directory"
+msgstr ""
+
+#: src/prefs.js:289
 msgid "Fit Mode"
 msgstr "Anpassungsmodus"
 
-#: src/prefs.js:232
+#: src/prefs.js:290
 msgid "Control how wallpaper fits within the monitor"
 msgstr "Steuere, wie das Hintergrundbild in den Monitor passt"
 
-#: src/prefs.js:233
+#: src/prefs.js:291
 msgid ""
 "\n"
 "    <b>Fill</b>: Stretch the wallpaper to fill the monitor.\n"
@@ -143,42 +159,76 @@ msgstr ""
 "passt (Seitenverhältnis beibehalten). \n"
 "    <b>Bedecken</b>: Das Hintergrundbild so skalieren, dass er den Monitor "
 "bedeckt (Seitenverhältnis beibehalten).\n"
-"    <b>Verkleinern</b>: Verkleinert bei bedarf das Hintergrundbild, um es "
-"an den Monitor anzupassen.\n"
+"    <b>Verkleinern</b>: Verkleinert bei bedarf das Hintergrundbild, um es an "
+"den Monitor anzupassen.\n"
 "    "
 
-#: src/prefs.js:241
+#: src/prefs.js:299
 msgid "Fill"
 msgstr "Ausfüllen"
 
-#: src/prefs.js:242
+#: src/prefs.js:300
 msgid "Contain"
 msgstr "Anpassen"
 
-#: src/prefs.js:243
+#: src/prefs.js:301
 msgid "Cover"
 msgstr "Bedecken"
 
-#: src/prefs.js:244
+#: src/prefs.js:302
 msgid "Scale-down"
 msgstr "Verkleinern"
 
-#: src/prefs.js:257
+#: src/prefs.js:315
 msgid "This feature requires Gtk 4.8 or above"
 msgstr "Diese Funktion benötigt Gtk 4.8 oder höher"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/prefs.js:330
+msgid "Change Wallpaper Mode"
+msgstr ""
+
+#: src/prefs.js:331
+msgid "Control how to change wallpapers automatically"
+msgstr ""
+
+#: src/prefs.js:332
+msgid ""
+"\n"
+"    <b>Sequential:</b> Preserve the directory sequence (descending order).\n"
+"    <b>Inverse Sequential:</b> Retrieve wallpapers in the opposite sequence "
+"(ascending order).\n"
+"    <b>Random:</b> Randomly select wallpapers from the directory.\n"
+"    "
+msgstr ""
+
+#: src/prefs.js:339
+msgid "Sequential"
+msgstr ""
+
+#: src/prefs.js:340
+msgid "Inverse Sequential"
+msgstr ""
+
+#: src/prefs.js:341
+msgid "Random"
+msgstr ""
+
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Pause"
 msgstr "pausieren"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Play"
 msgstr "abspielen"
 
-#: src/panelMenu.js:121 src/panelMenu.js:131
+#: src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Unmute Audio"
 msgstr "Stummschaltung aufheben"
 
-#: src/panelMenu.js:139
+#: src/panelMenu.js:187 src/panelMenu.js:195
+msgid "Next Wallpaper"
+msgstr ""
+
+#: src/panelMenu.js:206
 msgid "Preferences"
 msgstr "Einstellungen"

--- a/src/po/fr.po
+++ b/src/po/fr.po
@@ -22,7 +22,7 @@ msgstr ""
 msgid "General"
 msgstr "Général"
 
-#: src/prefs.js:53 src/panelMenu.js:121 src/panelMenu.js:131
+#: src/prefs.js:53 src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Mute Audio"
 msgstr "Muet"
 
@@ -34,62 +34,70 @@ msgstr "Volume"
 msgid "Show Panel Menu"
 msgstr "Afficher le raccourci de configuration"
 
-#: src/prefs.js:58
+#: src/prefs.js:56
+msgid "Change Wallpaper Automatically"
+msgstr ""
+
+#: src/prefs.js:59
+msgid "Change Wallpaper Interval (minutes)"
+msgstr ""
+
+#: src/prefs.js:62
 msgid "Experimental"
 msgstr "Expérimental"
 
-#: src/prefs.js:63
+#: src/prefs.js:67
 msgid "Experimental VA Plugin"
 msgstr "Plugin VA expérimental"
 
-#: src/prefs.js:65
+#: src/prefs.js:69
 msgid ""
 "Enable VA decoders which improve performance for Intel/AMD Wayland users"
 msgstr ""
 "Activer le décodeur VA qui améliore les performances pour les utilisateurs "
 "sous Wayland, ayant du matériel Intel/AMD"
 
-#: src/prefs.js:69
+#: src/prefs.js:73
 msgid "NVIDIA Stateless Decoders"
 msgstr "NVIDIA Stateless Decoders"
 
-#: src/prefs.js:71
+#: src/prefs.js:75
 msgid "Use new stateless NVIDIA decoders"
 msgstr "Utiliser le nouveau décodeur NVDIA Stateless"
 
-#: src/prefs.js:74
+#: src/prefs.js:78
 msgid "Developer"
 msgstr "Développeur"
 
-#: src/prefs.js:78
+#: src/prefs.js:82
 msgid "Debug Mode"
 msgstr "Débogage"
 
-#: src/prefs.js:80
+#: src/prefs.js:84
 msgid "Print debug messages to log"
 msgstr "Affiche les messages de débogage dans les logs"
 
-#: src/prefs.js:84
+#: src/prefs.js:88
 msgid "Force gtk4paintablesink"
 msgstr "Forcer gtk4paintablesink"
 
-#: src/prefs.js:86
+#: src/prefs.js:90
 msgid "Force use of gtk4paintablesink for video playback"
 msgstr "Forcer l'utilisation de gtk4paintablesink pour la lecture vidéo"
 
-#: src/prefs.js:90
+#: src/prefs.js:94
 msgid "Force GtkMediaFile"
 msgstr "Forcer GtkMediaFile"
 
-#: src/prefs.js:92
+#: src/prefs.js:96
 msgid "Force use of GtkMediaFile for video playback"
 msgstr "Forcer l'utilisation de GtkMediaFile pour la lecture vidéo"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid "Startup Delay"
 msgstr "Délai au démarrage"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid ""
 "Add a startup delay (in milliseconds) to mitigate compatibility issues with "
 "other extensions"
@@ -97,35 +105,43 @@ msgstr ""
 "Ajouter un délai (en millisecondes) afin d'éviter les problèmes de "
 "compatibilités avec d'autres extensions"
 
-#: src/prefs.js:174
+#: src/prefs.js:178
 msgid "Video Path"
 msgstr "Chemin vers la vidéo"
 
-#: src/prefs.js:180 src/prefs.js:205
+#: src/prefs.js:184 src/prefs.js:209 src/prefs.js:242 src/prefs.js:263
 msgid "None"
 msgstr "None"
 
-#: src/prefs.js:192
+#: src/prefs.js:196
 msgid "Open File"
 msgstr "Ouvrir le fichier"
 
-#: src/prefs.js:197
+#: src/prefs.js:201 src/prefs.js:256
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/prefs.js:198 src/prefs.js:214
+#: src/prefs.js:202 src/prefs.js:218 src/prefs.js:257 src/prefs.js:272
 msgid "Open"
 msgstr "Ouvrir"
 
-#: src/prefs.js:231
+#: src/prefs.js:236
+msgid "Change Wallpaper Directory Path"
+msgstr ""
+
+#: src/prefs.js:251
+msgid "Select Directory"
+msgstr ""
+
+#: src/prefs.js:289
 msgid "Fit Mode"
 msgstr "Mode de fond d'écran"
 
-#: src/prefs.js:232
+#: src/prefs.js:290
 msgid "Control how wallpaper fits within the monitor"
 msgstr "Gérer l'affichage du fond d'écran dans l'écran"
 
-#: src/prefs.js:233
+#: src/prefs.js:291
 msgid ""
 "\n"
 "    <b>Fill</b>: Stretch the wallpaper to fill the monitor.\n"
@@ -147,38 +163,72 @@ msgstr ""
 "si besoin, sinon garde la taille originale.\n"
 "    "
 
-#: src/prefs.js:241
+#: src/prefs.js:299
 msgid "Fill"
 msgstr "Remplir"
 
-#: src/prefs.js:242
+#: src/prefs.js:300
 msgid "Contain"
 msgstr "Contenir"
 
-#: src/prefs.js:243
+#: src/prefs.js:301
 msgid "Cover"
 msgstr "Couvrir"
 
-#: src/prefs.js:244
+#: src/prefs.js:302
 msgid "Scale-down"
 msgstr "Mise à l'échelle"
 
-#: src/prefs.js:257
+#: src/prefs.js:315
 msgid "This feature requires Gtk 4.8 or above"
 msgstr "Cette fonctionnalité requiet la version 4.0 de Gtk ou supérieure"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/prefs.js:330
+msgid "Change Wallpaper Mode"
+msgstr ""
+
+#: src/prefs.js:331
+msgid "Control how to change wallpapers automatically"
+msgstr ""
+
+#: src/prefs.js:332
+msgid ""
+"\n"
+"    <b>Sequential:</b> Preserve the directory sequence (descending order).\n"
+"    <b>Inverse Sequential:</b> Retrieve wallpapers in the opposite sequence "
+"(ascending order).\n"
+"    <b>Random:</b> Randomly select wallpapers from the directory.\n"
+"    "
+msgstr ""
+
+#: src/prefs.js:339
+msgid "Sequential"
+msgstr ""
+
+#: src/prefs.js:340
+msgid "Inverse Sequential"
+msgstr ""
+
+#: src/prefs.js:341
+msgid "Random"
+msgstr ""
+
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Pause"
 msgstr "Pause"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Play"
 msgstr "Reprendre"
 
-#: src/panelMenu.js:121 src/panelMenu.js:131
+#: src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Unmute Audio"
 msgstr "Activer le son"
 
-#: src/panelMenu.js:139
+#: src/panelMenu.js:187 src/panelMenu.js:195
+msgid "Next Wallpaper"
+msgstr ""
+
+#: src/panelMenu.js:206
 msgid "Preferences"
 msgstr "Paramètres"

--- a/src/po/hanabi-extension@jeffshee.github.io.pot
+++ b/src/po/hanabi-extension@jeffshee.github.io.pot
@@ -21,7 +21,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/prefs.js:53 src/panelMenu.js:121 src/panelMenu.js:131
+#: src/prefs.js:53 src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Mute Audio"
 msgstr ""
 
@@ -33,94 +33,110 @@ msgstr ""
 msgid "Show Panel Menu"
 msgstr ""
 
-#: src/prefs.js:58
+#: src/prefs.js:56
+msgid "Change Wallpaper Automatically"
+msgstr ""
+
+#: src/prefs.js:59
+msgid "Change Wallpaper Interval (minutes)"
+msgstr ""
+
+#: src/prefs.js:62
 msgid "Experimental"
 msgstr ""
 
-#: src/prefs.js:63
+#: src/prefs.js:67
 msgid "Experimental VA Plugin"
 msgstr ""
 
-#: src/prefs.js:65
+#: src/prefs.js:69
 msgid ""
 "Enable VA decoders which improve performance for Intel/AMD Wayland users"
 msgstr ""
 
-#: src/prefs.js:69
+#: src/prefs.js:73
 msgid "NVIDIA Stateless Decoders"
 msgstr ""
 
-#: src/prefs.js:71
+#: src/prefs.js:75
 msgid "Use new stateless NVIDIA decoders"
 msgstr ""
 
-#: src/prefs.js:74
+#: src/prefs.js:78
 msgid "Developer"
 msgstr ""
 
-#: src/prefs.js:78
+#: src/prefs.js:82
 msgid "Debug Mode"
 msgstr ""
 
-#: src/prefs.js:80
+#: src/prefs.js:84
 msgid "Print debug messages to log"
 msgstr ""
 
-#: src/prefs.js:84
+#: src/prefs.js:88
 msgid "Force gtk4paintablesink"
 msgstr ""
 
-#: src/prefs.js:86
+#: src/prefs.js:90
 msgid "Force use of gtk4paintablesink for video playback"
 msgstr ""
 
-#: src/prefs.js:90
+#: src/prefs.js:94
 msgid "Force GtkMediaFile"
 msgstr ""
 
-#: src/prefs.js:92
+#: src/prefs.js:96
 msgid "Force use of GtkMediaFile for video playback"
 msgstr ""
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid "Startup Delay"
 msgstr ""
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid ""
 "Add a startup delay (in milliseconds) to mitigate compatibility issues with "
 "other extensions"
 msgstr ""
 
-#: src/prefs.js:174
+#: src/prefs.js:178
 msgid "Video Path"
 msgstr ""
 
-#: src/prefs.js:180 src/prefs.js:205
+#: src/prefs.js:184 src/prefs.js:209 src/prefs.js:242 src/prefs.js:263
 msgid "None"
 msgstr ""
 
-#: src/prefs.js:192
+#: src/prefs.js:196
 msgid "Open File"
 msgstr ""
 
-#: src/prefs.js:197
+#: src/prefs.js:201 src/prefs.js:256
 msgid "Cancel"
 msgstr ""
 
-#: src/prefs.js:198 src/prefs.js:214
+#: src/prefs.js:202 src/prefs.js:218 src/prefs.js:257 src/prefs.js:272
 msgid "Open"
 msgstr ""
 
-#: src/prefs.js:231
+#: src/prefs.js:236
+msgid "Change Wallpaper Directory Path"
+msgstr ""
+
+#: src/prefs.js:251
+msgid "Select Directory"
+msgstr ""
+
+#: src/prefs.js:289
 msgid "Fit Mode"
 msgstr ""
 
-#: src/prefs.js:232
+#: src/prefs.js:290
 msgid "Control how wallpaper fits within the monitor"
 msgstr ""
 
-#: src/prefs.js:233
+#: src/prefs.js:291
 msgid ""
 "\n"
 "    <b>Fill</b>: Stretch the wallpaper to fill the monitor.\n"
@@ -133,38 +149,72 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/prefs.js:241
+#: src/prefs.js:299
 msgid "Fill"
 msgstr ""
 
-#: src/prefs.js:242
+#: src/prefs.js:300
 msgid "Contain"
 msgstr ""
 
-#: src/prefs.js:243
+#: src/prefs.js:301
 msgid "Cover"
 msgstr ""
 
-#: src/prefs.js:244
+#: src/prefs.js:302
 msgid "Scale-down"
 msgstr ""
 
-#: src/prefs.js:257
+#: src/prefs.js:315
 msgid "This feature requires Gtk 4.8 or above"
 msgstr ""
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/prefs.js:330
+msgid "Change Wallpaper Mode"
+msgstr ""
+
+#: src/prefs.js:331
+msgid "Control how to change wallpapers automatically"
+msgstr ""
+
+#: src/prefs.js:332
+msgid ""
+"\n"
+"    <b>Sequential:</b> Preserve the directory sequence (descending order).\n"
+"    <b>Inverse Sequential:</b> Retrieve wallpapers in the opposite sequence "
+"(ascending order).\n"
+"    <b>Random:</b> Randomly select wallpapers from the directory.\n"
+"    "
+msgstr ""
+
+#: src/prefs.js:339
+msgid "Sequential"
+msgstr ""
+
+#: src/prefs.js:340
+msgid "Inverse Sequential"
+msgstr ""
+
+#: src/prefs.js:341
+msgid "Random"
+msgstr ""
+
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Pause"
 msgstr ""
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Play"
 msgstr ""
 
-#: src/panelMenu.js:121 src/panelMenu.js:131
+#: src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Unmute Audio"
 msgstr ""
 
-#: src/panelMenu.js:139
+#: src/panelMenu.js:187 src/panelMenu.js:195
+msgid "Next Wallpaper"
+msgstr ""
+
+#: src/panelMenu.js:206
 msgid "Preferences"
 msgstr ""

--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -21,7 +21,7 @@ msgstr ""
 msgid "General"
 msgstr "一般"
 
-#: src/prefs.js:53 src/panelMenu.js:121 src/panelMenu.js:131
+#: src/prefs.js:53 src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Mute Audio"
 msgstr "音声をミュート"
 
@@ -33,97 +33,113 @@ msgstr "音量"
 msgid "Show Panel Menu"
 msgstr "パネルメニューを表示"
 
-#: src/prefs.js:58
+#: src/prefs.js:56
+msgid "Change Wallpaper Automatically"
+msgstr ""
+
+#: src/prefs.js:59
+msgid "Change Wallpaper Interval (minutes)"
+msgstr ""
+
+#: src/prefs.js:62
 msgid "Experimental"
 msgstr "実験的機能"
 
-#: src/prefs.js:63
+#: src/prefs.js:67
 msgid "Experimental VA Plugin"
 msgstr "実験的VAプラグイン"
 
-#: src/prefs.js:65
+#: src/prefs.js:69
 msgid ""
 "Enable VA decoders which improve performance for Intel/AMD Wayland users"
 msgstr ""
 "パフォーマンスを向上させるためのVAデコーダを有効にします\n"
 "（Intel/AMD Waylandユーザー向け）"
 
-#: src/prefs.js:69
+#: src/prefs.js:73
 msgid "NVIDIA Stateless Decoders"
 msgstr "NVIDIAステートレスデコーダ"
 
-#: src/prefs.js:71
+#: src/prefs.js:75
 msgid "Use new stateless NVIDIA decoders"
 msgstr "新たに実装されたステートレスNVIDIAデコーダを使用します"
 
-#: src/prefs.js:74
+#: src/prefs.js:78
 msgid "Developer"
 msgstr "開発者向けオプション"
 
-#: src/prefs.js:78
+#: src/prefs.js:82
 msgid "Debug Mode"
 msgstr "デバッグモード"
 
-#: src/prefs.js:80
+#: src/prefs.js:84
 msgid "Print debug messages to log"
 msgstr "デバッグメッセージをログに出力します"
 
-#: src/prefs.js:84
+#: src/prefs.js:88
 msgid "Force gtk4paintablesink"
 msgstr "gtk4paintablesinkを優先"
 
-#: src/prefs.js:86
+#: src/prefs.js:90
 msgid "Force use of gtk4paintablesink for video playback"
 msgstr "動画再生にgtk4paintablesinkを優先的に使用します"
 
-#: src/prefs.js:90
+#: src/prefs.js:94
 msgid "Force GtkMediaFile"
 msgstr "GtkMediaFileを優先"
 
-#: src/prefs.js:92
+#: src/prefs.js:96
 msgid "Force use of GtkMediaFile for video playback"
 msgstr "動画再生にGtkMediaFileを優先的に使用します"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid "Startup Delay"
 msgstr "起動遅延"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid ""
 "Add a startup delay (in milliseconds) to mitigate compatibility issues with "
 "other extensions"
 msgstr ""
 "他の拡張機能との相性問題を解消するために、起動を少し遅らせます（ミリ秒単位）"
 
-#: src/prefs.js:174
+#: src/prefs.js:178
 msgid "Video Path"
 msgstr "動画ファイルのパス"
 
-#: src/prefs.js:180 src/prefs.js:205
+#: src/prefs.js:184 src/prefs.js:209 src/prefs.js:242 src/prefs.js:263
 msgid "None"
 msgstr "なし"
 
-#: src/prefs.js:192
+#: src/prefs.js:196
 msgid "Open File"
 msgstr "ファイルを開く"
 
-#: src/prefs.js:197
+#: src/prefs.js:201 src/prefs.js:256
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: src/prefs.js:198 src/prefs.js:214
+#: src/prefs.js:202 src/prefs.js:218 src/prefs.js:257 src/prefs.js:272
 msgid "Open"
 msgstr "開く"
 
-#: src/prefs.js:231
+#: src/prefs.js:236
+msgid "Change Wallpaper Directory Path"
+msgstr ""
+
+#: src/prefs.js:251
+msgid "Select Directory"
+msgstr ""
+
+#: src/prefs.js:289
 msgid "Fit Mode"
 msgstr "フィットモード"
 
-#: src/prefs.js:232
+#: src/prefs.js:290
 msgid "Control how wallpaper fits within the monitor"
 msgstr "壁紙をモニターにフィットする方法を設定します"
 
-#: src/prefs.js:233
+#: src/prefs.js:291
 msgid ""
 "\n"
 "    <b>Fill</b>: Stretch the wallpaper to fill the monitor.\n"
@@ -145,38 +161,72 @@ msgstr ""
 "\t壁紙のサイズがモニターより小さい場合は元のサイズを維持します。\n"
 "    "
 
-#: src/prefs.js:241
+#: src/prefs.js:299
 msgid "Fill"
 msgstr "Fill"
 
-#: src/prefs.js:242
+#: src/prefs.js:300
 msgid "Contain"
 msgstr "Contain"
 
-#: src/prefs.js:243
+#: src/prefs.js:301
 msgid "Cover"
 msgstr "Cover"
 
-#: src/prefs.js:244
+#: src/prefs.js:302
 msgid "Scale-down"
 msgstr "Scale-down"
 
-#: src/prefs.js:257
+#: src/prefs.js:315
 msgid "This feature requires Gtk 4.8 or above"
 msgstr "この機能を使用するには、Gtk 4.8以上が必要です"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/prefs.js:330
+msgid "Change Wallpaper Mode"
+msgstr ""
+
+#: src/prefs.js:331
+msgid "Control how to change wallpapers automatically"
+msgstr ""
+
+#: src/prefs.js:332
+msgid ""
+"\n"
+"    <b>Sequential:</b> Preserve the directory sequence (descending order).\n"
+"    <b>Inverse Sequential:</b> Retrieve wallpapers in the opposite sequence "
+"(ascending order).\n"
+"    <b>Random:</b> Randomly select wallpapers from the directory.\n"
+"    "
+msgstr ""
+
+#: src/prefs.js:339
+msgid "Sequential"
+msgstr ""
+
+#: src/prefs.js:340
+msgid "Inverse Sequential"
+msgstr ""
+
+#: src/prefs.js:341
+msgid "Random"
+msgstr ""
+
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Pause"
 msgstr "一時停止"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Play"
 msgstr "再生"
 
-#: src/panelMenu.js:121 src/panelMenu.js:131
+#: src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Unmute Audio"
 msgstr "音声のミュートを解除"
 
-#: src/panelMenu.js:139
+#: src/panelMenu.js:187 src/panelMenu.js:195
+msgid "Next Wallpaper"
+msgstr ""
+
+#: src/panelMenu.js:206
 msgid "Preferences"
 msgstr "設定"

--- a/src/po/nb_NO.po
+++ b/src/po/nb_NO.po
@@ -9,8 +9,8 @@ msgstr ""
 "POT-Creation-Date: 2023-09-02 19:13+0900\n"
 "PO-Revision-Date: 2023-09-10 11:53+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
-"Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/"
-"gnome-ext-hanabi/gnome-ext-hanabi/nb_NO/>\n"
+"Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/gnome-"
+"ext-hanabi/gnome-ext-hanabi/nb_NO/>\n"
 "Language: nb_NO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,7 +22,7 @@ msgstr ""
 msgid "General"
 msgstr "Generelt"
 
-#: src/prefs.js:53 src/panelMenu.js:121 src/panelMenu.js:131
+#: src/prefs.js:53 src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Mute Audio"
 msgstr "Forstum lyd"
 
@@ -34,60 +34,68 @@ msgstr "Lydstyrkenivå"
 msgid "Show Panel Menu"
 msgstr "Vis panelmeny"
 
-#: src/prefs.js:58
+#: src/prefs.js:56
+msgid "Change Wallpaper Automatically"
+msgstr ""
+
+#: src/prefs.js:59
+msgid "Change Wallpaper Interval (minutes)"
+msgstr ""
+
+#: src/prefs.js:62
 msgid "Experimental"
 msgstr "Eksperimentelt"
 
-#: src/prefs.js:63
+#: src/prefs.js:67
 msgid "Experimental VA Plugin"
 msgstr "Eksperimentell VA-programtillegg"
 
-#: src/prefs.js:65
+#: src/prefs.js:69
 msgid ""
 "Enable VA decoders which improve performance for Intel/AMD Wayland users"
 msgstr "Skru på VA-dekodere, for bedre ytelse for Intel/AMD på Wayland"
 
-#: src/prefs.js:69
+#: src/prefs.js:73
 msgid "NVIDIA Stateless Decoders"
 msgstr "Tilstandsløse NVIDIA-dekodere"
 
-#: src/prefs.js:71
+#: src/prefs.js:75
 msgid "Use new stateless NVIDIA decoders"
 msgstr "Bruk nye tilstandsløse NVIDIA-dekodere"
 
-#: src/prefs.js:74
+#: src/prefs.js:78
 msgid "Developer"
 msgstr "Utvikler"
 
-#: src/prefs.js:78
+#: src/prefs.js:82
 msgid "Debug Mode"
 msgstr "Avlusingsmodus"
 
-#: src/prefs.js:80
+#: src/prefs.js:84
 msgid "Print debug messages to log"
 msgstr "Skriv ut avlusingsmeldinger til logg"
 
-#: src/prefs.js:84
+#: src/prefs.js:88
 msgid "Force gtk4paintablesink"
 msgstr "Påtving gtk4paintablesink"
 
-#: src/prefs.js:86
+#: src/prefs.js:90
 msgid "Force use of gtk4paintablesink for video playback"
 msgstr "Påtving bruk av gtk4paintablesink for videoavspilling"
 
-#: src/prefs.js:90
+#: src/prefs.js:94
 msgid "Force GtkMediaFile"
 msgstr "Påtving GtkMediaFile"
 
-#: src/prefs.js:92
+#: src/prefs.js:96
 msgid "Force use of GtkMediaFile for video playback"
 msgstr "Påtving bruk av GtkMediaFile for videoavspilling"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid "Startup Delay"
 msgstr "Oppstartsforsinkelse"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid ""
 "Add a startup delay (in milliseconds) to mitigate compatibility issues with "
 "other extensions"
@@ -95,35 +103,43 @@ msgstr ""
 "Tillagt (antall ms) oppstartsforsinkelse for å unngå kompabilitetsproblemer "
 "med andre utvidelser"
 
-#: src/prefs.js:174
+#: src/prefs.js:178
 msgid "Video Path"
 msgstr "Videosti"
 
-#: src/prefs.js:180 src/prefs.js:205
+#: src/prefs.js:184 src/prefs.js:209 src/prefs.js:242 src/prefs.js:263
 msgid "None"
 msgstr "Ingen"
 
-#: src/prefs.js:192
+#: src/prefs.js:196
 msgid "Open File"
 msgstr "Åpne fil"
 
-#: src/prefs.js:197
+#: src/prefs.js:201 src/prefs.js:256
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/prefs.js:198 src/prefs.js:214
+#: src/prefs.js:202 src/prefs.js:218 src/prefs.js:257 src/prefs.js:272
 msgid "Open"
 msgstr "Åpne"
 
-#: src/prefs.js:231
+#: src/prefs.js:236
+msgid "Change Wallpaper Directory Path"
+msgstr ""
+
+#: src/prefs.js:251
+msgid "Select Directory"
+msgstr ""
+
+#: src/prefs.js:289
 msgid "Fit Mode"
 msgstr "Åpne fil"
 
-#: src/prefs.js:232
+#: src/prefs.js:290
 msgid "Control how wallpaper fits within the monitor"
 msgstr "Kontroller hvordan bakgrunnsbildet passer på skjermen"
 
-#: src/prefs.js:233
+#: src/prefs.js:291
 #, fuzzy
 msgid ""
 "\n"
@@ -138,48 +154,82 @@ msgid ""
 msgstr ""
 "\n"
 "    <b>Fyll</b>: Strekk bakgrunnsbildet for å fylle skjermen.\n"
-"    <b>Tilpass</b>: Skaler bakgrunnsbildet til å passe skjermen ("
-"sideretningsforhold er beholdt).\n"
-"    <b>Omslag</b>: Skaler bakgrunnsbildet til å dekke skjermen ("
-"sideretningsforhold er beholdt).\n"
+"    <b>Tilpass</b>: Skaler bakgrunnsbildet til å passe skjermen "
+"(sideretningsforhold er beholdt).\n"
+"    <b>Omslag</b>: Skaler bakgrunnsbildet til å dekke skjermen "
+"(sideretningsforhold er beholdt).\n"
 "    <b>Skaler ned</b>: Skaler ned til bakgrunnsbildet for å fylle skjermen "
 "ved behov. Ellers blir opprinnelig størrelse beholdt.\n"
 "    "
 
-#: src/prefs.js:241
+#: src/prefs.js:299
 msgid "Fill"
 msgstr "Fyll"
 
-#: src/prefs.js:242
+#: src/prefs.js:300
 #, fuzzy
 msgid "Contain"
 msgstr "Tilpass"
 
-#: src/prefs.js:243
+#: src/prefs.js:301
 msgid "Cover"
 msgstr "Omslag"
 
-#: src/prefs.js:244
+#: src/prefs.js:302
 msgid "Scale-down"
 msgstr "Skaler ned"
 
-#: src/prefs.js:257
+#: src/prefs.js:315
 #, fuzzy
 msgid "This feature requires Gtk 4.8 or above"
 msgstr "Funksjonen krever GTK 4.8 eller høyere"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/prefs.js:330
+msgid "Change Wallpaper Mode"
+msgstr ""
+
+#: src/prefs.js:331
+msgid "Control how to change wallpapers automatically"
+msgstr ""
+
+#: src/prefs.js:332
+msgid ""
+"\n"
+"    <b>Sequential:</b> Preserve the directory sequence (descending order).\n"
+"    <b>Inverse Sequential:</b> Retrieve wallpapers in the opposite sequence "
+"(ascending order).\n"
+"    <b>Random:</b> Randomly select wallpapers from the directory.\n"
+"    "
+msgstr ""
+
+#: src/prefs.js:339
+msgid "Sequential"
+msgstr ""
+
+#: src/prefs.js:340
+msgid "Inverse Sequential"
+msgstr ""
+
+#: src/prefs.js:341
+msgid "Random"
+msgstr ""
+
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Pause"
 msgstr "Pause"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Play"
 msgstr "Spill"
 
-#: src/panelMenu.js:121 src/panelMenu.js:131
+#: src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Unmute Audio"
 msgstr "Opphev forstummelse av lyd"
 
-#: src/panelMenu.js:139
+#: src/panelMenu.js:187 src/panelMenu.js:195
+msgid "Next Wallpaper"
+msgstr ""
+
+#: src/panelMenu.js:206
 msgid "Preferences"
 msgstr "Innstillinger"

--- a/src/po/pt.po
+++ b/src/po/pt.po
@@ -9,8 +9,8 @@ msgstr ""
 "POT-Creation-Date: 2023-09-02 19:13+0900\n"
 "PO-Revision-Date: 2024-01-07 14:06+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
-"Language-Team: Portuguese <https://hosted.weblate.org/projects/"
-"gnome-ext-hanabi/gnome-ext-hanabi/pt/>\n"
+"Language-Team: Portuguese <https://hosted.weblate.org/projects/gnome-ext-"
+"hanabi/gnome-ext-hanabi/pt/>\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,7 +22,7 @@ msgstr ""
 msgid "General"
 msgstr "Geral"
 
-#: src/prefs.js:53 src/panelMenu.js:121 src/panelMenu.js:131
+#: src/prefs.js:53 src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Mute Audio"
 msgstr "Desligar Som"
 
@@ -34,62 +34,70 @@ msgstr "Volume do Som"
 msgid "Show Panel Menu"
 msgstr "Mostrar Menu de Painel"
 
-#: src/prefs.js:58
+#: src/prefs.js:56
+msgid "Change Wallpaper Automatically"
+msgstr ""
+
+#: src/prefs.js:59
+msgid "Change Wallpaper Interval (minutes)"
+msgstr ""
+
+#: src/prefs.js:62
 msgid "Experimental"
 msgstr "Opções Experimentais"
 
-#: src/prefs.js:63
+#: src/prefs.js:67
 msgid "Experimental VA Plugin"
 msgstr "Plugin VA Experimental"
 
-#: src/prefs.js:65
+#: src/prefs.js:69
 msgid ""
 "Enable VA decoders which improve performance for Intel/AMD Wayland users"
 msgstr ""
 "Ativar decodificadores VA que melhoram o desempenho para utilizadores de "
 "Wayland com Intel/AMD"
 
-#: src/prefs.js:69
+#: src/prefs.js:73
 msgid "NVIDIA Stateless Decoders"
 msgstr "Decodificadores sem estado da NVIDIA"
 
-#: src/prefs.js:71
+#: src/prefs.js:75
 msgid "Use new stateless NVIDIA decoders"
 msgstr "Utilizar os novos decodificadores sem estado da NVIDIA"
 
-#: src/prefs.js:74
+#: src/prefs.js:78
 msgid "Developer"
 msgstr "Opções para Programadores"
 
-#: src/prefs.js:78
+#: src/prefs.js:82
 msgid "Debug Mode"
 msgstr "Modo de Depuração"
 
-#: src/prefs.js:80
+#: src/prefs.js:84
 msgid "Print debug messages to log"
 msgstr "Enviar mensagens de depuração ao registo (Debug)"
 
-#: src/prefs.js:84
+#: src/prefs.js:88
 msgid "Force gtk4paintablesink"
 msgstr "Forçar gtk4paintablesink"
 
-#: src/prefs.js:86
+#: src/prefs.js:90
 msgid "Force use of gtk4paintablesink for video playback"
 msgstr "Forçar o uso do gtk4paintablesink para a reprodução dos vídeos"
 
-#: src/prefs.js:90
+#: src/prefs.js:94
 msgid "Force GtkMediaFile"
 msgstr "Forçar GtkMediaFile"
 
-#: src/prefs.js:92
+#: src/prefs.js:96
 msgid "Force use of GtkMediaFile for video playback"
 msgstr "Forçar o uso do GtkMediaFile para a reprodução dos vídeos"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid "Startup Delay"
 msgstr "Atraso de inicialização"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid ""
 "Add a startup delay (in milliseconds) to mitigate compatibility issues with "
 "other extensions"
@@ -97,35 +105,43 @@ msgstr ""
 "Adicionar atraso de inicialização (em milissegundos) para impedir problemas "
 "com outras extensões"
 
-#: src/prefs.js:174
+#: src/prefs.js:178
 msgid "Video Path"
 msgstr "Localização do Vídeo"
 
-#: src/prefs.js:180 src/prefs.js:205
+#: src/prefs.js:184 src/prefs.js:209 src/prefs.js:242 src/prefs.js:263
 msgid "None"
 msgstr "Nenhum"
 
-#: src/prefs.js:192
+#: src/prefs.js:196
 msgid "Open File"
 msgstr "Abrir Ficheiro"
 
-#: src/prefs.js:197
+#: src/prefs.js:201 src/prefs.js:256
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/prefs.js:198 src/prefs.js:214
+#: src/prefs.js:202 src/prefs.js:218 src/prefs.js:257 src/prefs.js:272
 msgid "Open"
 msgstr "Abrir"
 
-#: src/prefs.js:231
+#: src/prefs.js:236
+msgid "Change Wallpaper Directory Path"
+msgstr ""
+
+#: src/prefs.js:251
+msgid "Select Directory"
+msgstr ""
+
+#: src/prefs.js:289
 msgid "Fit Mode"
 msgstr "Ajuste do Papel de Parede"
 
-#: src/prefs.js:232
+#: src/prefs.js:290
 msgid "Control how wallpaper fits within the monitor"
 msgstr "Modificar como o papel de parede se ajusta no seu monitor"
 
-#: src/prefs.js:233
+#: src/prefs.js:291
 msgid ""
 "\n"
 "    <b>Fill</b>: Stretch the wallpaper to fill the monitor.\n"
@@ -148,38 +164,72 @@ msgstr ""
 "para caber no monitor.\n"
 "    "
 
-#: src/prefs.js:241
+#: src/prefs.js:299
 msgid "Fill"
 msgstr "Preencher"
 
-#: src/prefs.js:242
+#: src/prefs.js:300
 msgid "Contain"
 msgstr "Conter"
 
-#: src/prefs.js:243
+#: src/prefs.js:301
 msgid "Cover"
 msgstr "Cobrir"
 
-#: src/prefs.js:244
+#: src/prefs.js:302
 msgid "Scale-down"
 msgstr "Diminuir"
 
-#: src/prefs.js:257
+#: src/prefs.js:315
 msgid "This feature requires Gtk 4.8 or above"
 msgstr "Essa funcionalidade precisa de GTK 4.8 ou alguma versão superior"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/prefs.js:330
+msgid "Change Wallpaper Mode"
+msgstr ""
+
+#: src/prefs.js:331
+msgid "Control how to change wallpapers automatically"
+msgstr ""
+
+#: src/prefs.js:332
+msgid ""
+"\n"
+"    <b>Sequential:</b> Preserve the directory sequence (descending order).\n"
+"    <b>Inverse Sequential:</b> Retrieve wallpapers in the opposite sequence "
+"(ascending order).\n"
+"    <b>Random:</b> Randomly select wallpapers from the directory.\n"
+"    "
+msgstr ""
+
+#: src/prefs.js:339
+msgid "Sequential"
+msgstr ""
+
+#: src/prefs.js:340
+msgid "Inverse Sequential"
+msgstr ""
+
+#: src/prefs.js:341
+msgid "Random"
+msgstr ""
+
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Pause"
 msgstr "Pausar"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Play"
 msgstr "Reproduzir"
 
-#: src/panelMenu.js:121 src/panelMenu.js:131
+#: src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Unmute Audio"
 msgstr "Ligar Som"
 
-#: src/panelMenu.js:139
+#: src/panelMenu.js:187 src/panelMenu.js:195
+msgid "Next Wallpaper"
+msgstr ""
+
+#: src/panelMenu.js:206
 msgid "Preferences"
 msgstr "Preferências"

--- a/src/po/pt_BR.po
+++ b/src/po/pt_BR.po
@@ -21,7 +21,7 @@ msgstr ""
 msgid "General"
 msgstr "Geral"
 
-#: src/prefs.js:53 src/panelMenu.js:121 src/panelMenu.js:131
+#: src/prefs.js:53 src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Mute Audio"
 msgstr "Desligar Som"
 
@@ -33,62 +33,70 @@ msgstr "Volume do Som"
 msgid "Show Panel Menu"
 msgstr "Mostrar Menu de Painel"
 
-#: src/prefs.js:58
+#: src/prefs.js:56
+msgid "Change Wallpaper Automatically"
+msgstr "Mudar Wallpaper Automaticamente"
+
+#: src/prefs.js:59
+msgid "Change Wallpaper Interval (minutes)"
+msgstr "Intervalo p/ Mudar Wallpaper (minutos)"
+
+#: src/prefs.js:62
 msgid "Experimental"
 msgstr "Opções Experimentais"
 
-#: src/prefs.js:63
+#: src/prefs.js:67
 msgid "Experimental VA Plugin"
 msgstr "Plugin VA Experimental"
 
-#: src/prefs.js:65
+#: src/prefs.js:69
 msgid ""
 "Enable VA decoders which improve performance for Intel/AMD Wayland users"
 msgstr ""
 "Habilitar decodificadores VA que melhoram o desempenho para usuários de "
 "Wayland com Intel/AMD"
 
-#: src/prefs.js:69
+#: src/prefs.js:73
 msgid "NVIDIA Stateless Decoders"
 msgstr "Decodificadores sem estado da NVIDIA"
 
-#: src/prefs.js:71
+#: src/prefs.js:75
 msgid "Use new stateless NVIDIA decoders"
 msgstr "Utilizar os novos decodificadores sem estado da NVIDIA"
 
-#: src/prefs.js:74
+#: src/prefs.js:78
 msgid "Developer"
 msgstr "Opções para Desenvolvedores"
 
-#: src/prefs.js:78
+#: src/prefs.js:82
 msgid "Debug Mode"
 msgstr "Modo de Depuração"
 
-#: src/prefs.js:80
+#: src/prefs.js:84
 msgid "Print debug messages to log"
 msgstr "Enviar mensagens de depuração para o registro (Debug)"
 
-#: src/prefs.js:84
+#: src/prefs.js:88
 msgid "Force gtk4paintablesink"
 msgstr "Forçar gtk4paintablesink"
 
-#: src/prefs.js:86
+#: src/prefs.js:90
 msgid "Force use of gtk4paintablesink for video playback"
 msgstr "Forçar o uso do gtk4paintablesink para a reprodução dos vídeos"
 
-#: src/prefs.js:90
+#: src/prefs.js:94
 msgid "Force GtkMediaFile"
 msgstr "Forçar GtkMediaFile"
 
-#: src/prefs.js:92
+#: src/prefs.js:96
 msgid "Force use of GtkMediaFile for video playback"
 msgstr "Forçar o uso do GtkMediaFile para a reprodução dos vídeos"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid "Startup Delay"
 msgstr "Atraso de inicialização"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid ""
 "Add a startup delay (in milliseconds) to mitigate compatibility issues with "
 "other extensions"
@@ -96,35 +104,43 @@ msgstr ""
 "Adicionar atraso de inicialização (em milissegundos) para impedir problemas "
 "com outras extensões"
 
-#: src/prefs.js:174
+#: src/prefs.js:178
 msgid "Video Path"
 msgstr "Localização do Vídeo"
 
-#: src/prefs.js:180 src/prefs.js:205
+#: src/prefs.js:184 src/prefs.js:209 src/prefs.js:242 src/prefs.js:263
 msgid "None"
 msgstr "Nenhum"
 
-#: src/prefs.js:192
+#: src/prefs.js:196
 msgid "Open File"
 msgstr "Abrir Arquivo"
 
-#: src/prefs.js:197
+#: src/prefs.js:201 src/prefs.js:256
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/prefs.js:198 src/prefs.js:214
+#: src/prefs.js:202 src/prefs.js:218 src/prefs.js:257 src/prefs.js:272
 msgid "Open"
 msgstr "Abrir"
 
-#: src/prefs.js:231
+#: src/prefs.js:236
+msgid "Change Wallpaper Directory Path"
+msgstr "Caminho do Diretório p/ Mudar Wallpaper"
+
+#: src/prefs.js:251
+msgid "Select Directory"
+msgstr "Selecionar Diretório"
+
+#: src/prefs.js:289
 msgid "Fit Mode"
 msgstr "Ajuste do Papel de Parede"
 
-#: src/prefs.js:232
+#: src/prefs.js:290
 msgid "Control how wallpaper fits within the monitor"
 msgstr "Modificar como o papel de parede se ajusta no seu monitor"
 
-#: src/prefs.js:233
+#: src/prefs.js:291
 msgid ""
 "\n"
 "    <b>Fill</b>: Stretch the wallpaper to fill the monitor.\n"
@@ -147,38 +163,80 @@ msgstr ""
 "para caber no monitor.\n"
 "    "
 
-#: src/prefs.js:241
+#: src/prefs.js:299
 msgid "Fill"
 msgstr "Preencher"
 
-#: src/prefs.js:242
+#: src/prefs.js:300
 msgid "Contain"
 msgstr "Conter"
 
-#: src/prefs.js:243
+#: src/prefs.js:301
 msgid "Cover"
 msgstr "Cobrir"
 
-#: src/prefs.js:244
+#: src/prefs.js:302
 msgid "Scale-down"
 msgstr "Diminuir"
 
-#: src/prefs.js:257
+#: src/prefs.js:315
 msgid "This feature requires Gtk 4.8 or above"
 msgstr "Essa funcionalidade precisa de GTK 4.8 ou alguma versão superior"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/prefs.js:330
+msgid "Change Wallpaper Mode"
+msgstr "Modo p/ Mudar Wallpaper"
+
+#: src/prefs.js:331
+msgid "Control how to change wallpapers automatically"
+msgstr "Controla como alterar wallpapers automaticamente"
+
+#: src/prefs.js:332
+msgid ""
+"\n"
+"    <b>Sequential:</b> Preserve the directory sequence (descending order).\n"
+"    <b>Inverse Sequential:</b> Retrieve wallpapers in the opposite sequence "
+"(ascending order).\n"
+"    <b>Random:</b> Randomly select wallpapers from the directory.\n"
+"    "
+msgstr ""
+"\n"
+"    <b>Sequencial:</b> Preservar a sequência de arquivos (ordem "
+"crescente).\n"
+"    <b>Sequencial Inversa:</b> Usar papéis de parede na sequência "
+"oposta (ordem decrescente).\n"
+"    <b>Aleatório:</b> Selecionar papéis de parede aleatoriamente do "
+"diretório.\n"
+"    "
+
+#: src/prefs.js:339
+msgid "Sequential"
+msgstr "Sequencial"
+
+#: src/prefs.js:340
+msgid "Inverse Sequential"
+msgstr "Sequencial Inversa"
+
+#: src/prefs.js:341
+msgid "Random"
+msgstr "Aleatório"
+
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Pause"
 msgstr "Pausar"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Play"
 msgstr "Reproduzir"
 
-#: src/panelMenu.js:121 src/panelMenu.js:131
+#: src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Unmute Audio"
 msgstr "Ligar Som"
 
-#: src/panelMenu.js:139
+#: src/panelMenu.js:187 src/panelMenu.js:195
+msgid "Next Wallpaper"
+msgstr "Próximo Wallpaper"
+
+#: src/panelMenu.js:206
 msgid "Preferences"
 msgstr "Preferências"

--- a/src/po/ru.po
+++ b/src/po/ru.po
@@ -24,7 +24,7 @@ msgstr ""
 msgid "General"
 msgstr "Общее"
 
-#: src/prefs.js:53 src/panelMenu.js:121 src/panelMenu.js:131
+#: src/prefs.js:53 src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Mute Audio"
 msgstr "Отключить звук"
 
@@ -36,63 +36,71 @@ msgstr "Уровень громкости"
 msgid "Show Panel Menu"
 msgstr "Показывать индикатор в панели состояния"
 
-#: src/prefs.js:58
+#: src/prefs.js:56
+msgid "Change Wallpaper Automatically"
+msgstr ""
+
+#: src/prefs.js:59
+msgid "Change Wallpaper Interval (minutes)"
+msgstr ""
+
+#: src/prefs.js:62
 msgid "Experimental"
 msgstr "Экспериментальные настройки"
 
-#: src/prefs.js:63
+#: src/prefs.js:67
 msgid "Experimental VA Plugin"
 msgstr "Экспериментальный плагин VA"
 
-#: src/prefs.js:65
+#: src/prefs.js:69
 msgid ""
 "Enable VA decoders which improve performance for Intel/AMD Wayland users"
 msgstr ""
 "Включите декодеры VA, которые повышают производительность для пользователей "
 "Intel/AMD на Wayland"
 
-#: src/prefs.js:69
+#: src/prefs.js:73
 msgid "NVIDIA Stateless Decoders"
 msgstr "Безэтапные декодеры NVIDIA"
 
-#: src/prefs.js:71
+#: src/prefs.js:75
 msgid "Use new stateless NVIDIA decoders"
 msgstr "Используйте новые декодеры NVIDIA без статических данных"
 
-#: src/prefs.js:74
+#: src/prefs.js:78
 msgid "Developer"
 msgstr "Настройки для разработчиков"
 
-#: src/prefs.js:78
+#: src/prefs.js:82
 msgid "Debug Mode"
 msgstr "Режим отладки"
 
-#: src/prefs.js:80
+#: src/prefs.js:84
 msgid "Print debug messages to log"
 msgstr "Вывод сообщений отладки в журнал"
 
-#: src/prefs.js:84
+#: src/prefs.js:88
 msgid "Force gtk4paintablesink"
 msgstr "Принудительно использовать gtk4paintablesink"
 
-#: src/prefs.js:86
+#: src/prefs.js:90
 msgid "Force use of gtk4paintablesink for video playback"
 msgstr ""
 "Принудительное использование gtk4paintablesink для воспроизведения видео"
 
-#: src/prefs.js:90
+#: src/prefs.js:94
 msgid "Force GtkMediaFile"
 msgstr "Принудительно использовать GtkMediaFile"
 
-#: src/prefs.js:92
+#: src/prefs.js:96
 msgid "Force use of GtkMediaFile for video playback"
 msgstr "Принудительное использование GtkMediaFile для воспроизведения видео"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid "Startup Delay"
 msgstr "Задержка запуска"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid ""
 "Add a startup delay (in milliseconds) to mitigate compatibility issues with "
 "other extensions"
@@ -100,35 +108,43 @@ msgstr ""
 "Добавьте задержку при запуске (в миллисекундах), чтобы уменьшить проблемы "
 "совместимости с другими расширениями"
 
-#: src/prefs.js:174
+#: src/prefs.js:178
 msgid "Video Path"
 msgstr "Путь до видеофайла"
 
-#: src/prefs.js:180 src/prefs.js:205
+#: src/prefs.js:184 src/prefs.js:209 src/prefs.js:242 src/prefs.js:263
 msgid "None"
 msgstr "Нет"
 
-#: src/prefs.js:192
+#: src/prefs.js:196
 msgid "Open File"
 msgstr "Открыть файл"
 
-#: src/prefs.js:197
+#: src/prefs.js:201 src/prefs.js:256
 msgid "Cancel"
 msgstr "Отмена"
 
-#: src/prefs.js:198 src/prefs.js:214
+#: src/prefs.js:202 src/prefs.js:218 src/prefs.js:257 src/prefs.js:272
 msgid "Open"
 msgstr "Открыть"
 
-#: src/prefs.js:231
+#: src/prefs.js:236
+msgid "Change Wallpaper Directory Path"
+msgstr ""
+
+#: src/prefs.js:251
+msgid "Select Directory"
+msgstr ""
+
+#: src/prefs.js:289
 msgid "Fit Mode"
 msgstr "Режим"
 
-#: src/prefs.js:232
+#: src/prefs.js:290
 msgid "Control how wallpaper fits within the monitor"
 msgstr "Контроль того, как обои вписываются в монитор"
 
-#: src/prefs.js:233
+#: src/prefs.js:291
 msgid ""
 "\n"
 "    <b>Fill</b>: Stretch the wallpaper to fill the monitor.\n"
@@ -142,46 +158,80 @@ msgid ""
 msgstr ""
 "\n"
 "    <b>Fill</b>: Потяните обои, чтобы заполнить монитор.\n"
-"<b> Масштабируйте обои, чтобы соответствовать монитору (соотношение сторон)."
-"\n"
+"<b> Масштабируйте обои, чтобы соответствовать монитору (соотношение "
+"сторон).\n"
 "<b> Масштабируйте обои, чтобы покрыть монитор (соотношение сторон).\n"
 "<b>Scale-down</b>: Положите на обои вниз, чтобы при необходимости уместить "
 "монитор, в противном случае сохраняйте его первоначальный размер.\n"
 ".\n"
 "    "
 
-#: src/prefs.js:241
+#: src/prefs.js:299
 msgid "Fill"
 msgstr "Заполнение"
 
-#: src/prefs.js:242
+#: src/prefs.js:300
 msgid "Contain"
 msgstr "Контейнер"
 
-#: src/prefs.js:243
+#: src/prefs.js:301
 msgid "Cover"
 msgstr "Наложение"
 
-#: src/prefs.js:244
+#: src/prefs.js:302
 msgid "Scale-down"
 msgstr "Сокращение масштаба"
 
-#: src/prefs.js:257
+#: src/prefs.js:315
 msgid "This feature requires Gtk 4.8 or above"
 msgstr "Эта функция требует Gtk 4.8 или выше"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/prefs.js:330
+msgid "Change Wallpaper Mode"
+msgstr ""
+
+#: src/prefs.js:331
+msgid "Control how to change wallpapers automatically"
+msgstr ""
+
+#: src/prefs.js:332
+msgid ""
+"\n"
+"    <b>Sequential:</b> Preserve the directory sequence (descending order).\n"
+"    <b>Inverse Sequential:</b> Retrieve wallpapers in the opposite sequence "
+"(ascending order).\n"
+"    <b>Random:</b> Randomly select wallpapers from the directory.\n"
+"    "
+msgstr ""
+
+#: src/prefs.js:339
+msgid "Sequential"
+msgstr ""
+
+#: src/prefs.js:340
+msgid "Inverse Sequential"
+msgstr ""
+
+#: src/prefs.js:341
+msgid "Random"
+msgstr ""
+
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Pause"
 msgstr "Приостановить"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Play"
 msgstr "Воспроизвести"
 
-#: src/panelMenu.js:121 src/panelMenu.js:131
+#: src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Unmute Audio"
 msgstr "Включить звук"
 
-#: src/panelMenu.js:139
+#: src/panelMenu.js:187 src/panelMenu.js:195
+msgid "Next Wallpaper"
+msgstr ""
+
+#: src/panelMenu.js:206
 msgid "Preferences"
 msgstr "Настройки"

--- a/src/po/tr.po
+++ b/src/po/tr.po
@@ -23,7 +23,7 @@ msgstr ""
 msgid "General"
 msgstr "Genel"
 
-#: src/prefs.js:53 src/panelMenu.js:121 src/panelMenu.js:131
+#: src/prefs.js:53 src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Mute Audio"
 msgstr "Sesi Sustur"
 
@@ -35,62 +35,70 @@ msgstr "Ses Düzeyi"
 msgid "Show Panel Menu"
 msgstr "Panel Menüsünü Göster"
 
-#: src/prefs.js:58
+#: src/prefs.js:56
+msgid "Change Wallpaper Automatically"
+msgstr ""
+
+#: src/prefs.js:59
+msgid "Change Wallpaper Interval (minutes)"
+msgstr ""
+
+#: src/prefs.js:62
 msgid "Experimental"
 msgstr "Deneysel"
 
-#: src/prefs.js:63
+#: src/prefs.js:67
 msgid "Experimental VA Plugin"
 msgstr "Deneysel VA Eklentisi"
 
-#: src/prefs.js:65
+#: src/prefs.js:69
 msgid ""
 "Enable VA decoders which improve performance for Intel/AMD Wayland users"
 msgstr ""
 "Intel/AMD Wayland kullanıcıları için başarımı artıran VA kod çözücülerini "
 "etkinleştir"
 
-#: src/prefs.js:69
+#: src/prefs.js:73
 msgid "NVIDIA Stateless Decoders"
 msgstr "NVIDIA Vatansız Kod Çözücüler"
 
-#: src/prefs.js:71
+#: src/prefs.js:75
 msgid "Use new stateless NVIDIA decoders"
 msgstr "Yeni durumsuz NVIDIA kod çözücüleri kullan"
 
-#: src/prefs.js:74
+#: src/prefs.js:78
 msgid "Developer"
 msgstr "Geliştirici"
 
-#: src/prefs.js:78
+#: src/prefs.js:82
 msgid "Debug Mode"
 msgstr "Hata Ayıklama Kipi"
 
-#: src/prefs.js:80
+#: src/prefs.js:84
 msgid "Print debug messages to log"
 msgstr "Hata ayıklama iletilerini günlüğe yazdır"
 
-#: src/prefs.js:84
+#: src/prefs.js:88
 msgid "Force gtk4paintablesink"
 msgstr "gtk4paintablesink'e zorla"
 
-#: src/prefs.js:86
+#: src/prefs.js:90
 msgid "Force use of gtk4paintablesink for video playback"
 msgstr "Video oynatmalarında gtk4paintablesink kullanımına zorla"
 
-#: src/prefs.js:90
+#: src/prefs.js:94
 msgid "Force GtkMediaFile"
 msgstr "GtkMediaFile'a zorla"
 
-#: src/prefs.js:92
+#: src/prefs.js:96
 msgid "Force use of GtkMediaFile for video playback"
 msgstr "Video oynatmalarında GtkMediaFile kullanımına zorla"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid "Startup Delay"
 msgstr "Başlangıç Gecikmesi"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid ""
 "Add a startup delay (in milliseconds) to mitigate compatibility issues with "
 "other extensions"
@@ -98,35 +106,43 @@ msgstr ""
 "Diğer uzantılarla uyumluluk sorunlarını azaltmak için başlangıç gecikmesi "
 "ekle (milisaniye cinsinden)"
 
-#: src/prefs.js:174
+#: src/prefs.js:178
 msgid "Video Path"
 msgstr "Video Yolu"
 
-#: src/prefs.js:180 src/prefs.js:205
+#: src/prefs.js:184 src/prefs.js:209 src/prefs.js:242 src/prefs.js:263
 msgid "None"
 msgstr "Yok"
 
-#: src/prefs.js:192
+#: src/prefs.js:196
 msgid "Open File"
 msgstr "Dosya Aç"
 
-#: src/prefs.js:197
+#: src/prefs.js:201 src/prefs.js:256
 msgid "Cancel"
 msgstr "İptal"
 
-#: src/prefs.js:198 src/prefs.js:214
+#: src/prefs.js:202 src/prefs.js:218 src/prefs.js:257 src/prefs.js:272
 msgid "Open"
 msgstr "Aç"
 
-#: src/prefs.js:231
+#: src/prefs.js:236
+msgid "Change Wallpaper Directory Path"
+msgstr ""
+
+#: src/prefs.js:251
+msgid "Select Directory"
+msgstr ""
+
+#: src/prefs.js:289
 msgid "Fit Mode"
 msgstr "Doldurma Kipi"
 
-#: src/prefs.js:232
+#: src/prefs.js:290
 msgid "Control how wallpaper fits within the monitor"
 msgstr "Duvar kağıdının ekrana nasıl sığdığını denetle"
 
-#: src/prefs.js:233
+#: src/prefs.js:291
 msgid ""
 "\n"
 "    <b>Fill</b>: Stretch the wallpaper to fill the monitor.\n"
@@ -148,38 +164,72 @@ msgstr ""
 "aksi takdirde özgün boyutu koru.\n"
 "    "
 
-#: src/prefs.js:241
+#: src/prefs.js:299
 msgid "Fill"
 msgstr "Doldur"
 
-#: src/prefs.js:242
+#: src/prefs.js:300
 msgid "Contain"
 msgstr "İçer"
 
-#: src/prefs.js:243
+#: src/prefs.js:301
 msgid "Cover"
 msgstr "Kapla"
 
-#: src/prefs.js:244
+#: src/prefs.js:302
 msgid "Scale-down"
 msgstr "Küçült"
 
-#: src/prefs.js:257
+#: src/prefs.js:315
 msgid "This feature requires Gtk 4.8 or above"
 msgstr "Bu özellik Gtk 4.8 veya üst sürümü gerektirir"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/prefs.js:330
+msgid "Change Wallpaper Mode"
+msgstr ""
+
+#: src/prefs.js:331
+msgid "Control how to change wallpapers automatically"
+msgstr ""
+
+#: src/prefs.js:332
+msgid ""
+"\n"
+"    <b>Sequential:</b> Preserve the directory sequence (descending order).\n"
+"    <b>Inverse Sequential:</b> Retrieve wallpapers in the opposite sequence "
+"(ascending order).\n"
+"    <b>Random:</b> Randomly select wallpapers from the directory.\n"
+"    "
+msgstr ""
+
+#: src/prefs.js:339
+msgid "Sequential"
+msgstr ""
+
+#: src/prefs.js:340
+msgid "Inverse Sequential"
+msgstr ""
+
+#: src/prefs.js:341
+msgid "Random"
+msgstr ""
+
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Pause"
 msgstr "Durdur"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Play"
 msgstr "Oynat"
 
-#: src/panelMenu.js:121 src/panelMenu.js:131
+#: src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Unmute Audio"
 msgstr "Sesi Aç"
 
-#: src/panelMenu.js:139
+#: src/panelMenu.js:187 src/panelMenu.js:195
+msgid "Next Wallpaper"
+msgstr ""
+
+#: src/panelMenu.js:206
 msgid "Preferences"
 msgstr "Tercihler"

--- a/src/po/uk.po
+++ b/src/po/uk.po
@@ -9,8 +9,8 @@ msgstr ""
 "POT-Creation-Date: 2023-09-02 19:13+0900\n"
 "PO-Revision-Date: 2024-01-02 16:08+0000\n"
 "Last-Translator: volkov <d2oo1dle2x@gmail.com>\n"
-"Language-Team: Ukrainian <https://hosted.weblate.org/projects/"
-"gnome-ext-hanabi/gnome-ext-hanabi/uk/>\n"
+"Language-Team: Ukrainian <https://hosted.weblate.org/projects/gnome-ext-"
+"hanabi/gnome-ext-hanabi/uk/>\n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,7 @@ msgstr ""
 msgid "General"
 msgstr "Загальні"
 
-#: src/prefs.js:53 src/panelMenu.js:121 src/panelMenu.js:131
+#: src/prefs.js:53 src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Mute Audio"
 msgstr "Заглушити аудіо"
 
@@ -35,62 +35,70 @@ msgstr "Рівень гучності"
 msgid "Show Panel Menu"
 msgstr "Показувати індикатор у панелі стану"
 
-#: src/prefs.js:58
+#: src/prefs.js:56
+msgid "Change Wallpaper Automatically"
+msgstr ""
+
+#: src/prefs.js:59
+msgid "Change Wallpaper Interval (minutes)"
+msgstr ""
+
+#: src/prefs.js:62
 msgid "Experimental"
 msgstr "Експериментальні налаштування"
 
-#: src/prefs.js:63
+#: src/prefs.js:67
 msgid "Experimental VA Plugin"
 msgstr "Експериментальний плагін відео-прискорення"
 
-#: src/prefs.js:65
+#: src/prefs.js:69
 msgid ""
 "Enable VA decoders which improve performance for Intel/AMD Wayland users"
 msgstr ""
 "Увімкнути декодери з відео-прискоренням які можуть покращити продуктивність "
 "для користувачів Intel/AMD на Wayland"
 
-#: src/prefs.js:69
+#: src/prefs.js:73
 msgid "NVIDIA Stateless Decoders"
 msgstr "Декодер NVIDIA"
 
-#: src/prefs.js:71
+#: src/prefs.js:75
 msgid "Use new stateless NVIDIA decoders"
 msgstr "Використовувати нові декодери NVIDIA"
 
-#: src/prefs.js:74
+#: src/prefs.js:78
 msgid "Developer"
 msgstr "Розробник"
 
-#: src/prefs.js:78
+#: src/prefs.js:82
 msgid "Debug Mode"
 msgstr "Режим налагодження"
 
-#: src/prefs.js:80
+#: src/prefs.js:84
 msgid "Print debug messages to log"
 msgstr "Надсилати повідомлення відлагодження до звіту"
 
-#: src/prefs.js:84
+#: src/prefs.js:88
 msgid "Force gtk4paintablesink"
 msgstr "Примусово використовувати gtk4paintablesink"
 
-#: src/prefs.js:86
+#: src/prefs.js:90
 msgid "Force use of gtk4paintablesink for video playback"
 msgstr "Примусово використовувати gtk4paintablesink для програвання відео"
 
-#: src/prefs.js:90
+#: src/prefs.js:94
 msgid "Force GtkMediaFile"
 msgstr "Примусово використовувати GtkMediaFile"
 
-#: src/prefs.js:92
+#: src/prefs.js:96
 msgid "Force use of GtkMediaFile for video playback"
 msgstr "Примусово використовувати GtkMediaFile для програвання відео"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid "Startup Delay"
 msgstr "Затримка запуску"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid ""
 "Add a startup delay (in milliseconds) to mitigate compatibility issues with "
 "other extensions"
@@ -98,35 +106,43 @@ msgstr ""
 "Додати затримку запуску (у мілісекунда) щоб виправити проблеми сумісності з "
 "іншими розширеннями"
 
-#: src/prefs.js:174
+#: src/prefs.js:178
 msgid "Video Path"
 msgstr "Шлях до відеофайлу"
 
-#: src/prefs.js:180 src/prefs.js:205
+#: src/prefs.js:184 src/prefs.js:209 src/prefs.js:242 src/prefs.js:263
 msgid "None"
 msgstr "Ні"
 
-#: src/prefs.js:192
+#: src/prefs.js:196
 msgid "Open File"
 msgstr "Відкрити файл"
 
-#: src/prefs.js:197
+#: src/prefs.js:201 src/prefs.js:256
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: src/prefs.js:198 src/prefs.js:214
+#: src/prefs.js:202 src/prefs.js:218 src/prefs.js:257 src/prefs.js:272
 msgid "Open"
 msgstr "Відкрити"
 
-#: src/prefs.js:231
+#: src/prefs.js:236
+msgid "Change Wallpaper Directory Path"
+msgstr ""
+
+#: src/prefs.js:251
+msgid "Select Directory"
+msgstr ""
+
+#: src/prefs.js:289
 msgid "Fit Mode"
 msgstr "Режим заповнення"
 
-#: src/prefs.js:232
+#: src/prefs.js:290
 msgid "Control how wallpaper fits within the monitor"
 msgstr "Керує як саме шпалери будуть вміщатися у моніторі"
 
-#: src/prefs.js:233
+#: src/prefs.js:291
 msgid ""
 "\n"
 "    <b>Fill</b>: Stretch the wallpaper to fill the monitor.\n"
@@ -144,43 +160,77 @@ msgstr ""
 "збереженням співвідношення сторін).\n"
 "    <b>Накладати</b>: Масштабувати шпалери щоб покрити монітор (зі "
 "збереженням співвідношення сторін).\n"
-"    <b>Зменшити масштаб</b>: Зменшити масштаб шпалер щоб заповнити монітор ("
-"якщо масштабування потребується), в іншому випадку використовувати "
+"    <b>Зменшити масштаб</b>: Зменшити масштаб шпалер щоб заповнити монітор "
+"(якщо масштабування потребується), в іншому випадку використовувати "
 "оригінальний розмір.\n"
 "    "
 
-#: src/prefs.js:241
+#: src/prefs.js:299
 msgid "Fill"
 msgstr "Заповнювати"
 
-#: src/prefs.js:242
+#: src/prefs.js:300
 msgid "Contain"
 msgstr "Утримувати"
 
-#: src/prefs.js:243
+#: src/prefs.js:301
 msgid "Cover"
 msgstr "Накладати"
 
-#: src/prefs.js:244
+#: src/prefs.js:302
 msgid "Scale-down"
 msgstr "Зменшити масштаб"
 
-#: src/prefs.js:257
+#: src/prefs.js:315
 msgid "This feature requires Gtk 4.8 or above"
 msgstr "Ця функція потребує Gtk 4.8 або вище"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/prefs.js:330
+msgid "Change Wallpaper Mode"
+msgstr ""
+
+#: src/prefs.js:331
+msgid "Control how to change wallpapers automatically"
+msgstr ""
+
+#: src/prefs.js:332
+msgid ""
+"\n"
+"    <b>Sequential:</b> Preserve the directory sequence (descending order).\n"
+"    <b>Inverse Sequential:</b> Retrieve wallpapers in the opposite sequence "
+"(ascending order).\n"
+"    <b>Random:</b> Randomly select wallpapers from the directory.\n"
+"    "
+msgstr ""
+
+#: src/prefs.js:339
+msgid "Sequential"
+msgstr ""
+
+#: src/prefs.js:340
+msgid "Inverse Sequential"
+msgstr ""
+
+#: src/prefs.js:341
+msgid "Random"
+msgstr ""
+
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Pause"
 msgstr "Призупинити"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Play"
 msgstr "Продовжити"
 
-#: src/panelMenu.js:121 src/panelMenu.js:131
+#: src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Unmute Audio"
 msgstr "Увімкнути звуки"
 
-#: src/panelMenu.js:139
+#: src/panelMenu.js:187 src/panelMenu.js:195
+msgid "Next Wallpaper"
+msgstr ""
+
+#: src/panelMenu.js:206
 msgid "Preferences"
 msgstr "Налаштування"

--- a/src/po/zh_Hans.po
+++ b/src/po/zh_Hans.po
@@ -22,7 +22,7 @@ msgstr ""
 msgid "General"
 msgstr "一般设置"
 
-#: src/prefs.js:53 src/panelMenu.js:121 src/panelMenu.js:131
+#: src/prefs.js:53 src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Mute Audio"
 msgstr "静音"
 
@@ -34,94 +34,110 @@ msgstr "音量"
 msgid "Show Panel Menu"
 msgstr "显示面板菜单"
 
-#: src/prefs.js:58
+#: src/prefs.js:56
+msgid "Change Wallpaper Automatically"
+msgstr ""
+
+#: src/prefs.js:59
+msgid "Change Wallpaper Interval (minutes)"
+msgstr ""
+
+#: src/prefs.js:62
 msgid "Experimental"
 msgstr "实验性"
 
-#: src/prefs.js:63
+#: src/prefs.js:67
 msgid "Experimental VA Plugin"
 msgstr "实验性 VA 插件"
 
-#: src/prefs.js:65
+#: src/prefs.js:69
 msgid ""
 "Enable VA decoders which improve performance for Intel/AMD Wayland users"
 msgstr "启用 VA 解码器以提高英特尔/AMD Wayland 用户的性能"
 
-#: src/prefs.js:69
+#: src/prefs.js:73
 msgid "NVIDIA Stateless Decoders"
 msgstr "NVIDIA 无状态解码器"
 
-#: src/prefs.js:71
+#: src/prefs.js:75
 msgid "Use new stateless NVIDIA decoders"
 msgstr "使用新的 NVIDIA 无状态解码器"
 
-#: src/prefs.js:74
+#: src/prefs.js:78
 msgid "Developer"
 msgstr "开发者"
 
-#: src/prefs.js:78
+#: src/prefs.js:82
 msgid "Debug Mode"
 msgstr "调试模式"
 
-#: src/prefs.js:80
+#: src/prefs.js:84
 msgid "Print debug messages to log"
 msgstr "将调试信息打印到日志中"
 
-#: src/prefs.js:84
+#: src/prefs.js:88
 msgid "Force gtk4paintablesink"
 msgstr "强制使用 gtk4paintablesink"
 
-#: src/prefs.js:86
+#: src/prefs.js:90
 msgid "Force use of gtk4paintablesink for video playback"
 msgstr "强制使用 gtk4paintablesink 播放视频"
 
-#: src/prefs.js:90
+#: src/prefs.js:94
 msgid "Force GtkMediaFile"
 msgstr "强制使用 GtkMediaFile"
 
-#: src/prefs.js:92
+#: src/prefs.js:96
 msgid "Force use of GtkMediaFile for video playback"
 msgstr "强制使用 GtkMediaFile 播放视频"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid "Startup Delay"
 msgstr "启动延迟"
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid ""
 "Add a startup delay (in milliseconds) to mitigate compatibility issues with "
 "other extensions"
 msgstr "增加启动延迟（以毫秒为单位）以减少与其它扩展的兼容性问题"
 
-#: src/prefs.js:174
+#: src/prefs.js:178
 msgid "Video Path"
 msgstr "视频路径"
 
-#: src/prefs.js:180 src/prefs.js:205
+#: src/prefs.js:184 src/prefs.js:209 src/prefs.js:242 src/prefs.js:263
 msgid "None"
 msgstr "无"
 
-#: src/prefs.js:192
+#: src/prefs.js:196
 msgid "Open File"
 msgstr "打开文件"
 
-#: src/prefs.js:197
+#: src/prefs.js:201 src/prefs.js:256
 msgid "Cancel"
 msgstr "取消"
 
-#: src/prefs.js:198 src/prefs.js:214
+#: src/prefs.js:202 src/prefs.js:218 src/prefs.js:257 src/prefs.js:272
 msgid "Open"
 msgstr "打开"
 
-#: src/prefs.js:231
+#: src/prefs.js:236
+msgid "Change Wallpaper Directory Path"
+msgstr ""
+
+#: src/prefs.js:251
+msgid "Select Directory"
+msgstr ""
+
+#: src/prefs.js:289
 msgid "Fit Mode"
 msgstr "适应模式"
 
-#: src/prefs.js:232
+#: src/prefs.js:290
 msgid "Control how wallpaper fits within the monitor"
 msgstr "控制壁纸在显示器内的贴合方式"
 
-#: src/prefs.js:233
+#: src/prefs.js:291
 msgid ""
 "\n"
 "    <b>Fill</b>: Stretch the wallpaper to fill the monitor.\n"
@@ -140,38 +156,72 @@ msgstr ""
 "    <b>缩放</b>：必要时缩放壁纸以适应显示器，否则保持原始大小。\n"
 "    "
 
-#: src/prefs.js:241
+#: src/prefs.js:299
 msgid "Fill"
 msgstr "填充"
 
-#: src/prefs.js:242
+#: src/prefs.js:300
 msgid "Contain"
 msgstr "包含"
 
-#: src/prefs.js:243
+#: src/prefs.js:301
 msgid "Cover"
 msgstr "覆盖"
 
-#: src/prefs.js:244
+#: src/prefs.js:302
 msgid "Scale-down"
 msgstr "缩减"
 
-#: src/prefs.js:257
+#: src/prefs.js:315
 msgid "This feature requires Gtk 4.8 or above"
 msgstr "此功能需要 Gtk 4.8 或更高版本"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/prefs.js:330
+msgid "Change Wallpaper Mode"
+msgstr ""
+
+#: src/prefs.js:331
+msgid "Control how to change wallpapers automatically"
+msgstr ""
+
+#: src/prefs.js:332
+msgid ""
+"\n"
+"    <b>Sequential:</b> Preserve the directory sequence (descending order).\n"
+"    <b>Inverse Sequential:</b> Retrieve wallpapers in the opposite sequence "
+"(ascending order).\n"
+"    <b>Random:</b> Randomly select wallpapers from the directory.\n"
+"    "
+msgstr ""
+
+#: src/prefs.js:339
+msgid "Sequential"
+msgstr ""
+
+#: src/prefs.js:340
+msgid "Inverse Sequential"
+msgstr ""
+
+#: src/prefs.js:341
+msgid "Random"
+msgstr ""
+
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Pause"
 msgstr "暂停"
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Play"
 msgstr "播放"
 
-#: src/panelMenu.js:121 src/panelMenu.js:131
+#: src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Unmute Audio"
 msgstr "取消静音"
 
-#: src/panelMenu.js:139
+#: src/panelMenu.js:187 src/panelMenu.js:195
+msgid "Next Wallpaper"
+msgstr ""
+
+#: src/panelMenu.js:206
 msgid "Preferences"
 msgstr "偏好设置"

--- a/src/po/zh_Hant.po
+++ b/src/po/zh_Hant.po
@@ -19,7 +19,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/prefs.js:53 src/panelMenu.js:121 src/panelMenu.js:131
+#: src/prefs.js:53 src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Mute Audio"
 msgstr ""
 
@@ -31,94 +31,110 @@ msgstr ""
 msgid "Show Panel Menu"
 msgstr ""
 
-#: src/prefs.js:58
+#: src/prefs.js:56
+msgid "Change Wallpaper Automatically"
+msgstr ""
+
+#: src/prefs.js:59
+msgid "Change Wallpaper Interval (minutes)"
+msgstr ""
+
+#: src/prefs.js:62
 msgid "Experimental"
 msgstr ""
 
-#: src/prefs.js:63
+#: src/prefs.js:67
 msgid "Experimental VA Plugin"
 msgstr ""
 
-#: src/prefs.js:65
+#: src/prefs.js:69
 msgid ""
 "Enable VA decoders which improve performance for Intel/AMD Wayland users"
 msgstr ""
 
-#: src/prefs.js:69
+#: src/prefs.js:73
 msgid "NVIDIA Stateless Decoders"
 msgstr ""
 
-#: src/prefs.js:71
+#: src/prefs.js:75
 msgid "Use new stateless NVIDIA decoders"
 msgstr ""
 
-#: src/prefs.js:74
+#: src/prefs.js:78
 msgid "Developer"
 msgstr ""
 
-#: src/prefs.js:78
+#: src/prefs.js:82
 msgid "Debug Mode"
 msgstr ""
 
-#: src/prefs.js:80
+#: src/prefs.js:84
 msgid "Print debug messages to log"
 msgstr ""
 
-#: src/prefs.js:84
+#: src/prefs.js:88
 msgid "Force gtk4paintablesink"
 msgstr ""
 
-#: src/prefs.js:86
+#: src/prefs.js:90
 msgid "Force use of gtk4paintablesink for video playback"
 msgstr ""
 
-#: src/prefs.js:90
+#: src/prefs.js:94
 msgid "Force GtkMediaFile"
 msgstr ""
 
-#: src/prefs.js:92
+#: src/prefs.js:96
 msgid "Force use of GtkMediaFile for video playback"
 msgstr ""
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid "Startup Delay"
 msgstr ""
 
-#: src/prefs.js:94
+#: src/prefs.js:98
 msgid ""
 "Add a startup delay (in milliseconds) to mitigate compatibility issues with "
 "other extensions"
 msgstr ""
 
-#: src/prefs.js:174
+#: src/prefs.js:178
 msgid "Video Path"
 msgstr ""
 
-#: src/prefs.js:180 src/prefs.js:205
+#: src/prefs.js:184 src/prefs.js:209 src/prefs.js:242 src/prefs.js:263
 msgid "None"
 msgstr ""
 
-#: src/prefs.js:192
+#: src/prefs.js:196
 msgid "Open File"
 msgstr ""
 
-#: src/prefs.js:197
+#: src/prefs.js:201 src/prefs.js:256
 msgid "Cancel"
 msgstr ""
 
-#: src/prefs.js:198 src/prefs.js:214
+#: src/prefs.js:202 src/prefs.js:218 src/prefs.js:257 src/prefs.js:272
 msgid "Open"
 msgstr ""
 
-#: src/prefs.js:231
+#: src/prefs.js:236
+msgid "Change Wallpaper Directory Path"
+msgstr ""
+
+#: src/prefs.js:251
+msgid "Select Directory"
+msgstr ""
+
+#: src/prefs.js:289
 msgid "Fit Mode"
 msgstr ""
 
-#: src/prefs.js:232
+#: src/prefs.js:290
 msgid "Control how wallpaper fits within the monitor"
 msgstr ""
 
-#: src/prefs.js:233
+#: src/prefs.js:291
 msgid ""
 "\n"
 "    <b>Fill</b>: Stretch the wallpaper to fill the monitor.\n"
@@ -131,38 +147,72 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/prefs.js:241
+#: src/prefs.js:299
 msgid "Fill"
 msgstr ""
 
-#: src/prefs.js:242
+#: src/prefs.js:300
 msgid "Contain"
 msgstr ""
 
-#: src/prefs.js:243
+#: src/prefs.js:301
 msgid "Cover"
 msgstr ""
 
-#: src/prefs.js:244
+#: src/prefs.js:302
 msgid "Scale-down"
 msgstr ""
 
-#: src/prefs.js:257
+#: src/prefs.js:315
 msgid "This feature requires Gtk 4.8 or above"
 msgstr ""
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/prefs.js:330
+msgid "Change Wallpaper Mode"
+msgstr ""
+
+#: src/prefs.js:331
+msgid "Control how to change wallpapers automatically"
+msgstr ""
+
+#: src/prefs.js:332
+msgid ""
+"\n"
+"    <b>Sequential:</b> Preserve the directory sequence (descending order).\n"
+"    <b>Inverse Sequential:</b> Retrieve wallpapers in the opposite sequence "
+"(ascending order).\n"
+"    <b>Random:</b> Randomly select wallpapers from the directory.\n"
+"    "
+msgstr ""
+
+#: src/prefs.js:339
+msgid "Sequential"
+msgstr ""
+
+#: src/prefs.js:340
+msgid "Inverse Sequential"
+msgstr ""
+
+#: src/prefs.js:341
+msgid "Random"
+msgstr ""
+
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Pause"
 msgstr ""
 
-#: src/panelMenu.js:92 src/panelMenu.js:112
+#: src/panelMenu.js:139 src/panelMenu.js:159
 msgid "Play"
 msgstr ""
 
-#: src/panelMenu.js:121 src/panelMenu.js:131
+#: src/panelMenu.js:168 src/panelMenu.js:178
 msgid "Unmute Audio"
 msgstr ""
 
-#: src/panelMenu.js:139
+#: src/panelMenu.js:187 src/panelMenu.js:195
+msgid "Next Wallpaper"
+msgstr ""
+
+#: src/panelMenu.js:206
 msgid "Preferences"
 msgstr ""

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -56,7 +56,7 @@ function fillPreferencesWindow(window) {
     prefsRowBoolean(generalGroup, _('Change Wallpaper Automatically'), 'change-wallpaper', '');
     prefsRowDirectoryPath(window, generalGroup);
     prefsRowChangeWallpaperMode(generalGroup);
-    prefsRowInt(generalGroup, _('Change Wallpaper Interval (minutes)'), 'change-wallpaper-interval', '', 0, 1440, 5, 0);
+    prefsRowInt(generalGroup, _('Change Wallpaper Interval (minutes)'), 'change-wallpaper-interval', '', 1, 1440, 5, 0);
 
     const experimentalGroup = new Adw.PreferencesGroup({
         title: _('Experimental'),

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -53,6 +53,10 @@ function fillPreferencesWindow(window) {
     prefsRowBoolean(generalGroup, _('Mute Audio'), 'mute', '');
     prefsRowInt(generalGroup, _('Volume Level'), 'volume', '', 0, 100, 1, 10);
     prefsRowBoolean(generalGroup, _('Show Panel Menu'), 'show-panel-menu', '');
+    prefsRowBoolean(generalGroup, _('Change Wallpaper Automatically'), 'change-wallpaper', '');
+    prefsRowDirectoryPath(window, generalGroup);
+    prefsRowChangeWallpaperMode(generalGroup);
+    prefsRowInt(generalGroup, _('Change Wallpaper Interval (minutes)'), 'change-wallpaper-interval', '', 0, 1440, 5, 0);
 
     const experimentalGroup = new Adw.PreferencesGroup({
         title: _('Experimental'),
@@ -225,6 +229,60 @@ function prefsRowVideoPath(window, prefsGroup) {
 
 /**
  *
+ * @param window
+ * @param prefsGroup
+ */
+function prefsRowDirectoryPath(window, prefsGroup) {
+    const title = _('Change Wallpaper Directory Path');
+    const key = 'change-wallpaper-directory-path';
+
+    let path = settings.get_string(key);
+    const row = new Adw.ActionRow({
+        title,
+        subtitle: `${path !== '' ? path : _('None')}`,
+    });
+    prefsGroup.add(row);
+
+    /**
+     *
+     */
+    function createDialog() {
+        let fileChooser = new Gtk.FileChooserDialog({
+            title: _('Select Directory'),
+            action: Gtk.FileChooserAction.SELECT_FOLDER,
+        });
+        fileChooser.set_modal(true);
+        fileChooser.set_transient_for(window);
+        fileChooser.add_button(_('Cancel'), Gtk.ResponseType.CANCEL);
+        fileChooser.add_button(_('Open'), Gtk.ResponseType.ACCEPT);
+
+        fileChooser.connect('response', (dialog, responseId) => {
+            if (responseId === Gtk.ResponseType.ACCEPT) {
+                let _path = dialog.get_file().get_path();
+                settings.set_string(key, _path);
+                row.subtitle = `${_path !== '' ? _path : _('None')}`;
+            }
+            dialog.destroy();
+        });
+        return fileChooser;
+    }
+
+    let button = new Adw.ButtonContent({
+        icon_name: 'document-open-symbolic',
+        label: _('Open'),
+    });
+
+    row.activatable_widget = button;
+    row.add_suffix(button);
+
+    row.connect('activated', () => {
+        let dialog = createDialog();
+        dialog.show();
+    });
+}
+
+/**
+ *
  * @param prefsGroup
  */
 function prefsRowFitMode(prefsGroup) {
@@ -261,5 +319,38 @@ function prefsRowFitMode(prefsGroup) {
 
     row.connect('notify::selected', () => {
         settings.set_int('content-fit', row.selected);
+    });
+}
+
+/**
+ *
+ * @param prefsGroup
+ */
+function prefsRowChangeWallpaperMode(prefsGroup) {
+    const title = _('Change Wallpaper Mode');
+    const subtitle = _('Control how to change wallpapers automatically');
+    const tooltip = _(`
+    <b>Sequential:</b> Preserve the directory sequence (descending order).
+    <b>Inverse Sequential:</b> Retrieve wallpapers in the opposite sequence (ascending order).
+    <b>Random:</b> Randomly select wallpapers from the directory.
+    `);
+
+    const items = Gtk.StringList.new([
+        _('Sequential'),
+        _('Inverse Sequential'),
+        _('Random'),
+    ]);
+
+    const row = new Adw.ComboRow({
+        title,
+        subtitle,
+        model: items,
+        selected: settings.get_int('change-wallpaper-mode'),
+    });
+    row.set_tooltip_markup(tooltip);
+    prefsGroup.add(row);
+
+    row.connect('notify::selected', () => {
+        settings.set_int('change-wallpaper-mode', row.selected);
     });
 }

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -553,6 +553,10 @@ const HanabiRenderer = GObject.registerClass(
             let currentIndex = 0; // Index to keep track of the current video
             let videoPaths = [];
             let dir = Gio.File.new_for_path(changeWallpaperDirectoryPath);
+            // Check if dir exists and is a directory
+            if (dir.query_file_type(Gio.FileQueryInfoFlags.NONE, null) !== Gio.FileType.DIRECTORY)
+                return;
+
             let enumerator = dir.enumerate_children(
                 'standard::*',
                 Gio.FileQueryInfoFlags.NONE,

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -71,11 +71,15 @@ let mute = extSettings ? extSettings.get_boolean('mute') : false;
 let nohide = false;
 let videoPath = extSettings ? extSettings.get_string('video-path') : '';
 let volume = extSettings ? extSettings.get_int('volume') / 100.0 : 0.5;
+let changeWallpaper = extSettings ? extSettings.get_boolean('change-wallpaper') : true;
+let changeWallpaperDirectoryPath = extSettings ? extSettings.get_string('change-wallpaper-directory-path') : '';
+let changeWallpaperMode = extSettings ? extSettings.get_int('change-wallpaper-mode') : 0;
+let changeWallpaperInterval = extSettings ? extSettings.get_int('change-wallpaper-interval') : 15;
 let windowDimension = {width: 1920, height: 1080};
 let windowed = false;
 let fullscreened = true;
 let isDebugMode = extSettings ? extSettings.get_boolean('debug-mode') : true;
-
+let changeWallpaperTimerID;
 
 const HanabiRenderer = GObject.registerClass(
     {
@@ -134,6 +138,19 @@ const HanabiRenderer = GObject.registerClass(
                 case 'volume':
                     volume = settings.get_int(key) / 100.0;
                     this.setVolume(volume);
+                    break;
+                case 'change-wallpaper':
+                    changeWallpaper = settings.get_boolean(key);
+                    this.setAutoWallpaper();
+                    break;
+                case 'change-wallpaper-interval':
+                    changeWallpaperInterval = settings.get_int(key);
+                    break;
+                case 'change-wallpaper-directory-path':
+                    changeWallpaperDirectoryPath = settings.get_string(key);
+                    break;
+                case 'change-wallpaper-mode':
+                    changeWallpaperMode = settings.get_int(key);
                     break;
                 case 'content-fit':
                     if (!haveContentFit)
@@ -404,6 +421,7 @@ const HanabiRenderer = GObject.registerClass(
             this._play.set_uri(file.get_uri());
 
             this.setPlay();
+            this.setAutoWallpaper();
 
             return widget;
         }
@@ -432,6 +450,7 @@ const HanabiRenderer = GObject.registerClass(
             const widget = this._getWidgetFromSharedPaintable();
 
             this.setPlay();
+            this.setAutoWallpaper();
 
             return widget;
         }
@@ -462,7 +481,6 @@ const HanabiRenderer = GObject.registerClass(
         _unexportDbus() {
             this._dbus.unexport();
         }
-
 
         /**
          * These workarounds are needed because get_volume() and get_muted() can be wrong in some cases.
@@ -530,6 +548,71 @@ const HanabiRenderer = GObject.registerClass(
             else if (this._media)
                 this._media.pause();
         }
+
+        setAutoWallpaper() {
+            let videoExts = ['.mp4', '.webm'];
+            let currentIndex = 0; // Index to keep track of the current video
+        
+            function getVideoPaths() {
+                let videoPaths = [];
+                let dir = Gio.File.new_for_path(changeWallpaperDirectoryPath);
+        
+                let enumerator = dir.enumerate_children(
+                    'standard::*',
+                    Gio.FileQueryInfoFlags.NONE,
+                    null
+                );
+        
+                let fileInfo;
+                while ((fileInfo = enumerator.next_file(null))) {
+                    let fileName = fileInfo.get_name();
+                    if (videoExts.some(ext => fileName.toLowerCase().endsWith(ext))) {
+                        let filePath = changeWallpaperDirectoryPath + '/' + fileName;
+                        videoPaths.push(filePath);
+                    }
+                }
+        
+                return videoPaths.sort();
+            }
+        
+            function setGSettings(videoPath) {
+                let gsettingsCommand = `gsettings set io.github.jeffshee.hanabi-extension video-path '${videoPath}'`;
+                GLib.spawn_command_line_async(gsettingsCommand);
+            }
+
+            function getRandomIndex(actualIndex, videosLength) {
+                if (videosLength <= 1)
+                    return actualIndex;
+
+                let newIndex;
+                do {
+                    newIndex = Math.floor(Math.random() * videosLength);
+                } while (newIndex === actualIndex);
+                return newIndex;
+            }
+        
+            function mainLoop() {
+                let videoPaths = getVideoPaths();
+                if (videoPaths.length > 0 && changeWallpaper) {
+                    let videoPath = videoPaths[currentIndex];
+                    setGSettings(videoPath);
+
+                    if (changeWallpaperMode === 0)
+                        currentIndex = (currentIndex + 1) % videoPaths.length;
+                    else if (changeWallpaperMode === 1)
+                        currentIndex = (currentIndex - 1 + videoPaths.length) % videoPaths.length;
+                    else if (changeWallpaperMode === 2)
+                        currentIndex = getRandomIndex(currentIndex, videoPaths.length);
+
+                    changeWallpaperTimerID = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, changeWallpaperInterval * 60, mainLoop); // Timer to run function again
+                }
+            }
+        
+            if (changeWallpaper && changeWallpaperDirectoryPath)
+                mainLoop();
+            else if (changeWallpaperTimerID)
+                GLib.source_remove(changeWallpaperTimerID); // Remove timer
+        }   
 
         get isPlaying() {
             return this._isPlaying;

--- a/src/schemas/io.github.jeffshee.hanabi-extension.gschema.xml
+++ b/src/schemas/io.github.jeffshee.hanabi-extension.gschema.xml
@@ -18,6 +18,30 @@
             <summary>Volume Level</summary>
         </key>
 
+        <key name="change-wallpaper" type="b">
+            <default>false</default>
+            <summary>Change Wallpaper</summary>
+        </key>
+
+        <key name="change-wallpaper-directory-path" type="s">
+            <default>''</default>
+            <summary>Change Wallpaper Directory Path</summary>
+            <description>Change Wallpaper Directory Path</description>
+        </key>
+        
+        <key name="change-wallpaper-interval" type="i">
+            <range min="0" max="1440" />
+            <default>15</default>
+            <summary>Change Wallpaper Interval (minutes)</summary>
+        </key>
+
+        <key name="change-wallpaper-mode" type="i">
+            <range min="0" max="3" />
+            <default>1</default>
+            <summary>Change Wallpaper Mode</summary>
+            <description>Control how to change wallpapers automatically</description>
+        </key>
+
         <key name="pause-on-fullscreen" type="b">
             <default>false</default>
             <summary>Pause on Fullscreen</summary>

--- a/src/schemas/io.github.jeffshee.hanabi-extension.gschema.xml
+++ b/src/schemas/io.github.jeffshee.hanabi-extension.gschema.xml
@@ -30,7 +30,7 @@
         </key>
         
         <key name="change-wallpaper-interval" type="i">
-            <range min="0" max="1440" />
+            <range min="1" max="1440" />
             <default>15</default>
             <summary>Change Wallpaper Interval (minutes)</summary>
         </key>


### PR DESCRIPTION
### Automatic Wallpaper Changer
I wanted to make it easier for users to set wallpapers that change automatically, so I made this contribution.

Features:
- Add "Next Wallpaper" to Panel Menu, that change to the next wallpaper (accordingly with the file in directory set by the user in filenames descending order);
- Add row "Change Wallpaper Automatically" to start changing wallpapers;
- Add row "Change Wallpaper Directory Path" to get wallpapers from a directory;
- Add row "Change Wallpaper Mode" to set the order to change wallpapers based in the filenames in directory (Sequential, Inverse Sequential and Random);
- Add row "Change Wallpaper Interval (minutes)" to change wallpaper based on time set by the user;
- Update .pot file and all .po files (pt_BR 100%);

<div align="center">
  <img src="https://github.com/jeffshee/gnome-ext-hanabi/assets/102198728/95af3982-7190-4763-bc96-fcf3f01a4825" alt="Image Alt Text">
</div>