### PR TITLE
fix: ubuntu regression

### DIFF
--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -40,21 +40,28 @@ let GstPlay = null;
 // GstPlay is available from GStreamer 1.20+
 try {
     GstPlay = imports.gi.GstPlay;
-} catch (e) {}
+} catch (e) {
+    console.error(e);
+    console.warn('GstPlay, or the typelib is not installed. Renderer will fallback to GtkMediaFile!');
+}
 const haveGstPlay = GstPlay !== null;
 
 let GstAudio = null;
 // Might not pre-installed on some distributions
 try {
     GstAudio = imports.gi.GstAudio;
-} catch (e) {}
+} catch (e) {
+    console.error(e);
+    console.warn('GstAudio, or the typelib is not installed.');
+}
 const haveGstAudio = GstAudio !== null;
 
 // ContentFit is available from Gtk 4.8+
 const haveContentFit = isGtkVersionAtLeast(4, 8);
 
 // Support for dmabus and graphics offload is available from Gtk 4.14+
-const haveGraphicsOffload = isGtkVersionAtLeast(4, 14);
+// FIXME: Disabled for now as it has issue with Ubuntu 24.04
+const haveGraphicsOffload = isGtkVersionAtLeast(4, 14) && false;
 
 // Use glsinkbin for Gst 1.24+
 const useGstGL = isGstVersionAtLeast(1, 24);

--- a/src/wallpaper.js
+++ b/src/wallpaper.js
@@ -31,7 +31,7 @@ const logger = new Logger.Logger();
 // Ref: https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js
 const BACKGROUND_FADE_ANIMATION_TIME = 1000;
 
-const CUSTOM_BACKGROUND_BOUNDS_PADDING = 2;
+// const CUSTOM_BACKGROUND_BOUNDS_PADDING = 2;
 
 /**
  * The widget that holds the window preview of the renderer.
@@ -75,23 +75,24 @@ export const LiveWallpaper = GObject.registerClass(
 
             this._roundedCornersEffect =
                 new RoundedCornersEffect.RoundedCornersEffect();
-            this._backgroundActor.add_effect(this._roundedCornersEffect);
+            // this._backgroundActor.add_effect(this._roundedCornersEffect);
 
             this.setPixelStep(this._monitorWidth, this._monitorHeight);
             this.setRoundedClipRadius(0.0);
             this.setRoundedClipBounds(0, 0, this._monitorWidth, this._monitorHeight);
 
-            this.connect('notify::allocation', () => {
-                let heightOffset = this.height - this._metaBackgroundGroup.get_parent().height;
-                this._roundedCornersEffect.setBounds(
-                    [
-                        CUSTOM_BACKGROUND_BOUNDS_PADDING,
-                        CUSTOM_BACKGROUND_BOUNDS_PADDING + heightOffset,
-                        this.width,
-                        this.height,
-                    ].map(e => e * this._monitorScale)
-                );
-            });
+            // FIXME: Bounds calculation is wrong if the layout isn't vanilla (with custom dock, panel, etc.), disabled for now.
+            // this.connect('notify::allocation', () => {
+            //     let heightOffset = this.height - this._metaBackgroundGroup.get_parent().height;
+            //     this._roundedCornersEffect.setBounds(
+            //         [
+            //             CUSTOM_BACKGROUND_BOUNDS_PADDING,
+            //             CUSTOM_BACKGROUND_BOUNDS_PADDING + heightOffset,
+            //             this.width,
+            //             this.height,
+            //         ].map(e => e * this._monitorScale)
+            //     );
+            // });
         }
 
         setPixelStep(width, height) {


### PR DESCRIPTION
### Changes
- Temporally disable graphics offload and rounded corners effect due to the regression. 

fix #154 