### PR TITLE
Fix extension crash on disable due to dock race condition

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -181,10 +181,14 @@ export default class HanabiExtension extends Extension {
     }
 
     disable() {
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, this.settings.get_int('startup-delay'), () => {
+            this.override.disable();
+            return false;
+        });
+
         this.settings = null;
         this.panelMenu.disable();
         Main.sessionMode.hasOverview = this.old_hasOverview;
-        this.override.disable();
         this.manager.disable();
         this.autoPause.disable();
 


### PR DESCRIPTION
Fix extension crash on disable due to dock race condition.

Fix #179, Fix #158

**Changes**
* Add delay to `override.disable()` using existing preferences dialog delay setting

This addresses the intermittent race condition where dock extensions (Ubuntu Dock/Dash-to-Dock) have null `dockManager` during state transitions.

Prevents crashes during screen state transitions (suspend/resume, lock/unlock). 

Only delays the problematic `override.disable()` call. All other cleanup happens immediately.

Tested on Ubuntu 24.04.2 LTS, GNOME Shell 46.0, X11.