### PR TITLE
feat: random start position

### DIFF
--- a/src/prefs.js
+++ b/src/prefs.js
@@ -55,6 +55,7 @@ export default class HanabiExtensionPreferences extends ExtensionPreferences {
             1,
             10
         );
+        prefsRowBoolean(window, generalGroup, _('Random Start Position'), 'random-start-position', _('Start playback from a random position each time a video starts'));
         prefsRowBoolean(
             window,
             generalGroup,

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -114,6 +114,7 @@ let mute = extSettings ? extSettings.get_boolean('mute') : false;
 let nohide = false;
 let videoPath = extSettings ? extSettings.get_string('video-path') : '';
 let volume = extSettings ? extSettings.get_int('volume') / 100.0 : 0.5;
+let randomStartPosition = extSettings ? extSettings.get_boolean('random-start-position') : false;
 let changeWallpaper = extSettings
     ? extSettings.get_boolean('change-wallpaper')
     : true;
@@ -150,6 +151,7 @@ const HanabiRenderer = GObject.registerClass(
             this._sharedPaintable = null;
             this._gstImplName = '';
             this._isPlaying = false;
+            this._randomStartPending = true;
             this._exportDbus();
             this._setupGst();
 
@@ -191,6 +193,9 @@ const HanabiRenderer = GObject.registerClass(
                 case 'volume':
                     volume = settings.get_int(key) / 100.0;
                     this.setVolume(volume);
+                    break;
+                case 'random-start-position':
+                    randomStartPosition = settings.get_boolean(key);
                     break;
                 case 'change-wallpaper':
                     changeWallpaper = settings.get_boolean(key);
@@ -500,10 +505,15 @@ const HanabiRenderer = GObject.registerClass(
                     new GLib.Variant('(b)', [this._isPlaying])
                 );
             });
+            this._adapter.connect('state-changed', (_adapter, state) => {
+                if (state >= GstPlay.PlayState.PAUSED)
+                    this._maybeSeekRandomGst();
+            });
 
             const file = Gio.File.new_for_path(videoPath);
             this._play.set_uri(file.get_uri());
 
+            this._markRandomStartPending();
             this.setPlay();
             this.setAutoWallpaper();
 
@@ -523,6 +533,7 @@ const HanabiRenderer = GObject.registerClass(
             this._media.connect('notify::prepared', () => {
                 this.setVolume(volume);
                 this.setMute(mute);
+                this._maybeSeekRandomMedia();
             });
             // Monitor playing state.
             this._media.connect('notify::playing', media => {
@@ -536,6 +547,7 @@ const HanabiRenderer = GObject.registerClass(
             this._sharedPaintable = this._media;
             const widget = this._getWidgetFromSharedPaintable();
 
+            this._markRandomStartPending();
             this.setPlay();
             this.setAutoWallpaper();
 
@@ -616,6 +628,7 @@ const HanabiRenderer = GObject.registerClass(
                 this._media.stream_unprepared();
                 this._media.file = file;
             }
+            this._markRandomStartPending();
             this.setPlay();
         }
 
@@ -721,6 +734,42 @@ const HanabiRenderer = GObject.registerClass(
 
         get isPlaying() {
             return this._isPlaying;
+        }
+
+        _markRandomStartPending() {
+            this._randomStartPending = true;
+        }
+
+        _maybeSeekRandomGst() {
+            if (!this._play || !randomStartPosition || !this._randomStartPending)
+                return;
+
+            let duration = this._play.get_duration();
+            if (!duration || duration <= 0) {
+                this._randomStartPending = false;
+                return;
+            }
+
+            let maxPosition = Math.max(duration - (Gst.SECOND || 1000000000), 0);
+            let position = Math.floor(Math.random() * (maxPosition + 1));
+            this._play.seek(position);
+            this._randomStartPending = false;
+        }
+
+        _maybeSeekRandomMedia() {
+            if (!this._media || !randomStartPosition || !this._randomStartPending)
+                return;
+
+            let duration = this._media.get_duration();
+            if (!duration || duration <= 0) {
+                this._randomStartPending = false;
+                return;
+            }
+
+            let maxPosition = Math.max(duration - GLib.USEC_PER_SEC, 0);
+            let position = Math.floor(Math.random() * (maxPosition + 1));
+            this._media.seek(position);
+            this._randomStartPending = false;
         }
     }
 );

--- a/src/schemas/io.github.jeffshee.hanabi-extension.gschema.xml
+++ b/src/schemas/io.github.jeffshee.hanabi-extension.gschema.xml
@@ -20,6 +20,12 @@
             <description>Set the volume level for audio playback</description>
         </key>
 
+        <key name="random-start-position" type="b">
+            <default>false</default>
+            <summary>Random Start Position</summary>
+            <description>Start playback from a random position each time a video starts</description>
+        </key>
+
         <key name="change-wallpaper" type="b">
             <default>false</default>
             <summary>Change Wallpaper</summary>


### PR DESCRIPTION
Added a "Random Start Position" preference and renderer support to start videos at a random timestamp each time playback begins. This applies to both GstPlay and GtkMediaFile backends, using the media duration to seek safely on start.

<img width="2560" height="1440" alt="Screenshot From 2026-01-21 11-06-39" src="https://github.com/user-attachments/assets/2f151d1e-4bc6-4fc3-917a-80e1a531301c" />
