### PR TITLE
Fixed Crash on Lock Screen

### DIFF
--- a/src/gnomeShellOverride.js
+++ b/src/gnomeShellOverride.js
@@ -221,11 +221,15 @@ export class GnomeShellOverride {
             }
         );
 
-        this._reloadBackgrounds();
+        if (!Main.sessionMode.isLocked) {
+            this._reloadBackgrounds();
+        }
     }
 
     disable() {
         this._injectionManager.clear();
-        this._reloadBackgrounds();
+        if (!Main.sessionMode.isLocked) {
+            this._reloadBackgrounds();
+        }
     }
 }


### PR DESCRIPTION
## Description

See issues #200 and #217. Hanabi makes calls to null objects when screen is locked.

## Solution

Wraps `this._reloadBackgrounds();` call with `if (!Main.sessionMode.isLocked)` to prevent calling null objects during screen lock.

## Testing

- [ ] ⚠️ Gnome 42
- [ ] ⚠️ Gnome 43
- [ ] ⚠️ Gnome 44
- [ ] ⚠️ Gnome 45
- [x] ✅ Gnome 46 (Ubuntu 24.04.4 LTS, x11)
- [ ] ⚠️ Gnome 47
- [ ] ⚠️ Gnome 48
- [ ] ⚠️ Gnome 49
- [ ] ⚠️ Gnome 50

> **Legend**
> ⚠️ Not tested
> ✅ Pass
> ⛔ Fail