### PR TITLE
Guard Blur my Shell compatibility during background reload

### DIFF
--- a/src/gnomeShellOverride.js
+++ b/src/gnomeShellOverride.js
@@ -57,7 +57,11 @@ export class GnomeShellOverride {
          * WorkspaceBackground has its own bgManager,
          * we have to recreate it to use our actors, so it can set radius to our actor.
          */
-        Main.overview._overview._controls._workspacesDisplay._updateWorkspacesViews();
+        try {
+            Main.overview._overview._controls._workspacesDisplay._updateWorkspacesViews();
+        } catch (e) {
+            // Suppress errors from extension conflicts (e.g. DING) during background reload
+        }
 
         /**
          *  Blur My Shell
@@ -108,7 +112,7 @@ export class GnomeShellOverride {
                     const cornerRadius = scaleFactor * BACKGROUND_CORNER_RADIUS_PIXELS;
 
                     const radius = Util.lerp(0, cornerRadius, this._stateAdjustment.value);
-                    this._bgManager.videoActor.setRoundedClipRadius(radius);
+                    this._bgManager.videoActor?.setRoundedClipRadius(radius);
                 };
             }
         );


### PR DESCRIPTION
## Summary
This improves compatibility with Blur my Shell during Hanabi background reloads.

## What changed
- wrap `_updateWorkspacesViews()` during background reload in `try/catch`
- guard `videoActor` access in `_updateBorderRadius()`

## Why
When Hanabi refreshes GNOME Shell backgrounds, other extensions can interfere with workspace background recreation. In that case, the current code can throw during reload or assume `videoActor` is always present. These guards make the reload path more tolerant and avoid breaking the wallpaper/blur interaction.

## Notes
Related debugging conversation: {conversation_link}

Co-Authored-By: Oz <oz-agent@warp.dev>
