### PR TITLE
fix: suppress dockManager null error during session transitions (#213)

### DIFF
--- a/src/gnomeShellOverride.js
+++ b/src/gnomeShellOverride.js
@@ -57,8 +57,12 @@ export class GnomeShellOverride {
          * WorkspaceBackground has its own bgManager,
          * we have to recreate it to use our actors, so it can set radius to our actor.
          */
-        Main.overview._overview._controls._workspacesDisplay._updateWorkspacesViews();
-
+        try {
+            Main.overview._overview._controls._workspacesDisplay._updateWorkspacesViews();
+        } catch (e) {
+            // Suppress potential null pointer exception during session transitions (e.g., lock/unlock)
+            // as discussed in issue #213.
+        }
         /**
          *  Blur My Shell
          */


### PR DESCRIPTION
This PR addresses the TypeError: can't access property "removables", dockManager is null error reported in #213.

The Issue:
On some systems (specifically tested on Ubuntu 24.04 / GNOME 46 / Wayland), the extension fails to reload properly after the user locks and unlocks the screen because dockManager is null at the moment of execution.

The Fix:
Wrapped the _updateWorkspacesViews() call in a try catch block. This prevents the extension from crashing/disabling itself during the reload sequence, allowing the wallpaper to resume playback normally once the shell is ready.

Fixes #213