### PR TITLE
add: GNOME Shell 50 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Please click on the image to view <i>(redirect to YouTube)</i>
 
 ## GNOME Shell Support
 
-| Version | ≤41 | 42  | 43  | 44  | 45  | 46  | 47  | 48  | 49  |
-| :-----: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-| Status  | ⛔  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
+| Version | ≤41 | 42  | 43  | 44  | 45  | 46  | 47  | 48  | 49  | 50  |
+| :-----: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
+| Status  | ⛔  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
 
 See also the section [Troubleshooting](#troubleshooting), for version-specific known issues.
 

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -36,7 +36,10 @@ const shellVersion = parseInt(Config.PACKAGE_VERSION.split('.')[0]);
 
 export class LaunchSubprocess {
     constructor(flags = Gio.SubprocessFlags.NONE) {
-        this._isX11 = !Meta.is_wayland_compositor();
+        if (shellVersion < 50)
+            this._isX11 = !Meta.is_wayland_compositor();
+        else
+            this._isX11 = false
 
         this._flags =
             flags |

--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -4,8 +4,9 @@
   "name": "Hanabi Extension",
   "settings-schema": "@settings_schema@",
   "shell-version": [
-    "45", "46", "47", "48", "49"
+    "45", "46", "47", "48", "49", "50"
   ],
+  "wayland-compatible": true,
   "url": "https://github.com/jeffshee/gnome-ext-hanabi",
   "uuid": "@uuid@",
   "version": @version@

--- a/src/windowManager.js
+++ b/src/windowManager.js
@@ -148,7 +148,10 @@ class ManagedWindow {
 
 export class WindowManager {
     constructor() {
-        this._isX11 = !Meta.is_wayland_compositor();
+        if (shellVersion < 50)
+            this._isX11 = !Meta.is_wayland_compositor();
+        else
+            this._isX11 = false
         this._windows = new Set();
         this._waylandClient = null;
     }


### PR DESCRIPTION
Set this._isX11 to False (no x11 support in Gnome 50)
Add "wayland-compatible": true in metadata