### PR TITLE
Fix Wayland detection on newer GNOME Shell versions

### DIFF
--- a/src/launcher.js
+++ b/src/launcher.js
@@ -36,7 +36,7 @@ const shellVersion = parseInt(Config.PACKAGE_VERSION.split('.')[0]);
 
 export class LaunchSubprocess {
     constructor(flags = Gio.SubprocessFlags.NONE) {
-        this._isX11 = !Meta.is_wayland_compositor();
+        this._isX11 = GLib.getenv('XDG_SESSION_TYPE') === 'x11';
 
         this._flags =
             flags |

--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -4,7 +4,7 @@
   "name": "Hanabi Extension",
   "settings-schema": "@settings_schema@",
   "shell-version": [
-    "45", "46", "47", "48", "49"
+    "45", "46", "47", "48", "49", "50"
   ],
   "url": "https://github.com/jeffshee/gnome-ext-hanabi",
   "uuid": "@uuid@",

--- a/src/windowManager.js
+++ b/src/windowManager.js
@@ -148,7 +148,7 @@ class ManagedWindow {
 
 export class WindowManager {
     constructor() {
-        this._isX11 = !Meta.is_wayland_compositor();
+        this._isX11 = GLib.getenv('XDG_SESSION_TYPE') === 'x11';
         this._windows = new Set();
         this._waylandClient = null;
     }


### PR DESCRIPTION
**Summary**

Fixes a compatibility issue with newer GNOME Shell versions where `Meta.is_wayland_compositor()` is no longer available.

**Problem**

The extension fails to load with:

```text
TypeError: Meta.is_wayland_compositor is not a function

**Changes

Replaced:**

this._isX11 = !Meta.is_wayland_compositor();

with:

this._isX11 = GLib.getenv('XDG_SESSION_TYPE') === 'x11';

**Updated in:**

src/launcher.js
src/windowManager.js

Tested

Tested locally on Ubuntu with GNOME Shell running under Wayland. After the change, the extension loads correctly.