### PR TITLE
feat: show live wallpaper on lock screen

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -136,11 +136,51 @@ export default class HanabiExtension extends Extension {
             }
         );
 
+        this._sessionModeUpdatedId = Main.sessionMode.connect('updated', () => {
+            this._onSessionModeUpdated();
+        });
+        this._showOnLockScreenChangedId = this.settings.connect(
+            'changed::show-on-lock-screen',
+            () => this._onSessionModeUpdated()
+        );
+
         this.isEnabled = true;
         if (this.launchRendererId)
             GLib.source_remove(this.launchRendererId);
 
         this.launchRenderer();
+    }
+
+    _onSessionModeUpdated() {
+        const isLockScreen = Main.sessionMode.currentMode === 'unlock-dialog';
+        const showOnLockScreen = this.settings?.get_boolean('show-on-lock-screen') ?? true;
+
+        if (isLockScreen && !showOnLockScreen)
+            this._suspendRenderer();
+        else if (!isLockScreen || showOnLockScreen)
+            this._resumeRenderer();
+    }
+
+    _suspendRenderer() {
+        if (this._rendererSuspended)
+            return;
+        this._rendererSuspended = true;
+        if (this.launchRendererId) {
+            GLib.source_remove(this.launchRendererId);
+            this.launchRendererId = 0;
+        }
+        if (this.currentProcess?.subprocess) {
+            this.currentProcess.cancellable.cancel();
+            this.currentProcess.subprocess.send_signal(15);
+        }
+    }
+
+    _resumeRenderer() {
+        if (!this._rendererSuspended)
+            return;
+        this._rendererSuspended = false;
+        if (this.isEnabled && !this.currentProcess)
+            this.launchRenderer();
     }
 
     getPlaybackState() {
@@ -185,7 +225,7 @@ export default class HanabiExtension extends Extension {
             }
             this.currentProcess = null;
             this.manager.set_wayland_client(null);
-            if (this.isEnabled) {
+            if (this.isEnabled && !this._rendererSuspended) {
                 if (this.launchRendererId)
                     GLib.source_remove(this.launchRendererId);
 
@@ -204,6 +244,17 @@ export default class HanabiExtension extends Extension {
 
     disable() {
         this.killCurrentProcess();
+        this._rendererSuspended = false;
+
+        if (this._sessionModeUpdatedId) {
+            Main.sessionMode.disconnect(this._sessionModeUpdatedId);
+            this._sessionModeUpdatedId = null;
+        }
+
+        if (this._showOnLockScreenChangedId) {
+            this.settings.disconnect(this._showOnLockScreenChangedId);
+            this._showOnLockScreenChangedId = null;
+        }
 
         if (this._showPanelMenuChangedId) {
             this.settings.disconnect(this._showPanelMenuChangedId);

--- a/src/gnomeShellOverride.js
+++ b/src/gnomeShellOverride.js
@@ -47,6 +47,7 @@ export class GnomeShellOverride {
         this._injectionManager = new InjectionManager();
         this._wallpaperActors = new Set();
         this._settings = settings;
+        this._settingsChangedIds = [];
     }
 
     _reloadBackgrounds() {
@@ -93,6 +94,23 @@ export class GnomeShellOverride {
         });
     }
 
+    _reloadLockScreenBackgrounds() {
+        // Only destroy and recreate lock screen wallpaper actors, leaving desktop actors intact.
+        for (const actor of [...this._wallpaperActors]) {
+            if (actor._metaBackgroundGroup?.style_class?.includes('screen-shield-background'))
+                actor.destroy();
+        }
+
+        const laters = this._getLaters();
+        if (laters) {
+            laters.add(Meta.LaterType.BEFORE_REDRAW, () => {
+                if (Main.screenShield?._dialog?._updateBackgrounds != null)
+                    Main.screenShield._dialog._updateBackgrounds();
+                return GLib.SOURCE_REMOVE;
+            });
+        }
+    }
+
     _getLaters() {
         if (global.compositor?.get_laters)
             return global.compositor.get_laters();
@@ -113,6 +131,11 @@ export class GnomeShellOverride {
             originalMethod => {
                 return function () {
                     const backgroundActor = originalMethod.call(this);
+
+                    // The lock screen container widget has style_class 'screen-shield-background'.
+                    const isLockScreen = this._container.style_class?.includes('screen-shield-background') ?? false;
+                    if (isLockScreen && !thisRef._settings?.get_boolean('show-on-lock-screen'))
+                        return backgroundActor;
 
                     // We need to pass radius to actors, so save a ref in bgManager.
                     this.videoActor = new Wallpaper.LiveWallpaper(
@@ -296,10 +319,22 @@ export class GnomeShellOverride {
             }
         );
 
+        if (this._settings) {
+            this._settingsChangedIds.push(
+                this._settings.connect('changed::show-on-lock-screen', () => {
+                    this._reloadLockScreenBackgrounds();
+                })
+            );
+        }
+
         this._reloadBackgrounds();
     }
 
     disable() {
+        for (const id of this._settingsChangedIds)
+            this._settings?.disconnect(id);
+        this._settingsChangedIds = [];
+
         this._injectionManager.clear();
         this._reloadBackgrounds();
     }

--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -3,6 +3,7 @@
   "gettext-domain": "@uuid@",
   "name": "Hanabi Extension",
   "settings-schema": "@settings_schema@",
+  "session-modes": ["user", "unlock-dialog"],
   "shell-version": [
     "45", "46", "47", "48", "49", "50"
   ],

--- a/src/po/hanabi-extension@jeffshee.github.io.pot
+++ b/src/po/hanabi-extension@jeffshee.github.io.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-ext-hanabi 1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-07 17:44+0900\n"
+"POT-Creation-Date: 2026-06-09 14:38+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -61,172 +61,180 @@ msgstr ""
 msgid "Show Panel Menu"
 msgstr ""
 
+#: src/prefs.js:69
+msgid "Show on Lock Screen"
+msgstr ""
+
 #: src/prefs.js:71
-msgid "Auto Pause"
+msgid "Show the live wallpaper on the lock screen"
 msgstr ""
 
 #: src/prefs.js:78
+msgid "Auto Pause"
+msgstr ""
+
+#: src/prefs.js:85
 msgid "Pause on Window Focus"
 msgstr ""
 
-#: src/prefs.js:80
+#: src/prefs.js:87
 msgid "Pause playback when any window is focused"
 msgstr ""
 
-#: src/prefs.js:86
+#: src/prefs.js:93
 msgid "Low Battery Threshold"
 msgstr ""
 
-#: src/prefs.js:88
+#: src/prefs.js:95
 msgid "Set the threshold percentage for low battery level"
 msgstr ""
 
-#: src/prefs.js:97
+#: src/prefs.js:104
 msgid "Pause on Media Player Playing"
 msgstr ""
 
-#: src/prefs.js:99
+#: src/prefs.js:106
 msgid "Pause playback when an MPRIS media player is playing media"
 msgstr ""
 
-#: src/prefs.js:106
+#: src/prefs.js:113
 msgid "Wallpaper Changer"
 msgstr ""
 
-#: src/prefs.js:112
+#: src/prefs.js:119
 msgid "Change Wallpaper Automatically"
 msgstr ""
 
-#: src/prefs.js:121
+#: src/prefs.js:128
 msgid "Change Wallpaper Interval (minutes)"
 msgstr ""
 
-#: src/prefs.js:134
+#: src/prefs.js:141
 msgid "Overview"
 msgstr ""
 
-#: src/prefs.js:140
+#: src/prefs.js:147
 msgid "Corner Radius"
 msgstr ""
 
-#: src/prefs.js:142
+#: src/prefs.js:149
 msgid ""
 "Rounded corner radius in pixels for workspace background in the overview"
 msgstr ""
 
-#: src/prefs.js:153
+#: src/prefs.js:160
 msgid "Experimental"
 msgstr ""
 
-#: src/prefs.js:159
+#: src/prefs.js:166
 msgid "Experimental VA Plugin"
 msgstr ""
 
-#: src/prefs.js:162
+#: src/prefs.js:169
 msgid ""
 "Enable VA decoders which improve performance for Intel/AMD Wayland users"
 msgstr ""
 
-#: src/prefs.js:168
+#: src/prefs.js:175
 msgid "NVIDIA Stateless Decoders"
 msgstr ""
 
-#: src/prefs.js:170
+#: src/prefs.js:177
 msgid "Use new stateless NVIDIA decoders"
 msgstr ""
 
-#: src/prefs.js:177
+#: src/prefs.js:184
 msgid "Developer"
 msgstr ""
 
-#: src/prefs.js:183
+#: src/prefs.js:190
 msgid "Debug Mode"
 msgstr ""
 
-#: src/prefs.js:185
+#: src/prefs.js:192
 msgid "Print debug messages to log"
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:197
 msgid "Prefer clappersink"
 msgstr ""
 
-#: src/prefs.js:192
+#: src/prefs.js:199
 msgid "Prefer clappersink over gtk4paintablesink for video playback"
 msgstr ""
 
-#: src/prefs.js:197
+#: src/prefs.js:204
 msgid "Force GtkMediaFile"
 msgstr ""
 
-#: src/prefs.js:199
+#: src/prefs.js:206
 msgid "Force use of GtkMediaFile for video playback"
 msgstr ""
 
-#: src/prefs.js:204
+#: src/prefs.js:211
 msgid "Enable Graphics Offload"
 msgstr ""
 
-#: src/prefs.js:207
+#: src/prefs.js:214
 msgid "Enable graphics offload for improved performance (requires GTK 4.14+)"
 msgstr ""
 
-#: src/prefs.js:213
+#: src/prefs.js:220
 msgid "Startup Delay"
 msgstr ""
 
-#: src/prefs.js:216
+#: src/prefs.js:223
 msgid ""
 "Add a startup delay (in milliseconds) to mitigate compatibility issues with "
 "other extensions"
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:233
 msgid "Border Stroke"
 msgstr ""
 
-#: src/prefs.js:228
+#: src/prefs.js:235
 msgid ""
 "Border width in pixels drawn inside the rounded-rect bounds (0 = disabled)"
 msgstr ""
 
-#: src/prefs.js:296
+#: src/prefs.js:303
 msgid "Video Path"
 msgstr ""
 
-#: src/prefs.js:302 src/prefs.js:327 src/prefs.js:356 src/prefs.js:377
+#: src/prefs.js:309 src/prefs.js:334 src/prefs.js:363 src/prefs.js:384
 msgid "None"
 msgstr ""
 
-#: src/prefs.js:314
+#: src/prefs.js:321
 msgid "Open File"
 msgstr ""
 
-#: src/prefs.js:319 src/prefs.js:370
+#: src/prefs.js:326 src/prefs.js:377
 msgid "Cancel"
 msgstr ""
 
-#: src/prefs.js:320 src/prefs.js:336 src/prefs.js:371 src/prefs.js:386
+#: src/prefs.js:327 src/prefs.js:343 src/prefs.js:378 src/prefs.js:393
 msgid "Open"
 msgstr ""
 
-#: src/prefs.js:350
+#: src/prefs.js:357
 msgid "Change Wallpaper Directory Path"
 msgstr ""
 
-#: src/prefs.js:365
+#: src/prefs.js:372
 msgid "Select Directory"
 msgstr ""
 
-#: src/prefs.js:400
+#: src/prefs.js:407
 msgid "Fit Mode"
 msgstr ""
 
-#: src/prefs.js:401
+#: src/prefs.js:408
 msgid "Control how wallpaper fits within the monitor"
 msgstr ""
 
-#: src/prefs.js:402
+#: src/prefs.js:409
 msgid ""
 "\n"
 "    <b>Fill</b>: Stretch the wallpaper to fill the monitor.\n"
@@ -239,35 +247,35 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/prefs.js:410
+#: src/prefs.js:417
 msgid "Fill"
 msgstr ""
 
-#: src/prefs.js:411
+#: src/prefs.js:418
 msgid "Contain"
 msgstr ""
 
-#: src/prefs.js:412
+#: src/prefs.js:419
 msgid "Cover"
 msgstr ""
 
-#: src/prefs.js:413
+#: src/prefs.js:420
 msgid "Scale-down"
 msgstr ""
 
-#: src/prefs.js:426
+#: src/prefs.js:433
 msgid "This feature requires Gtk 4.8 or above"
 msgstr ""
 
-#: src/prefs.js:438
+#: src/prefs.js:445
 msgid "Pause on Maximize or Fullscreen"
 msgstr ""
 
-#: src/prefs.js:440
+#: src/prefs.js:447
 msgid "Pause playback when there is maximized or fullscreen window"
 msgstr ""
 
-#: src/prefs.js:442
+#: src/prefs.js:449
 msgid ""
 "\n"
 "    <b>Never</b>: Disable this feature.\n"
@@ -278,27 +286,27 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/prefs.js:449 src/prefs.js:482
+#: src/prefs.js:456 src/prefs.js:489
 msgid "Never"
 msgstr ""
 
-#: src/prefs.js:450
+#: src/prefs.js:457
 msgid "Any Monitor"
 msgstr ""
 
-#: src/prefs.js:451
+#: src/prefs.js:458
 msgid "All Monitors"
 msgstr ""
 
-#: src/prefs.js:471
+#: src/prefs.js:478
 msgid "Pause on Battery"
 msgstr ""
 
-#: src/prefs.js:473
+#: src/prefs.js:480
 msgid "Pause playback when the device is on battery or the battery is low"
 msgstr ""
 
-#: src/prefs.js:475
+#: src/prefs.js:482
 msgid ""
 "\n"
 "    <b>Never</b>: Disable this feature.\n"
@@ -308,23 +316,23 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/prefs.js:483
+#: src/prefs.js:490
 msgid "Low Battery"
 msgstr ""
 
-#: src/prefs.js:484
+#: src/prefs.js:491
 msgid "Always"
 msgstr ""
 
-#: src/prefs.js:504
+#: src/prefs.js:511
 msgid "Change Wallpaper Mode"
 msgstr ""
 
-#: src/prefs.js:505
+#: src/prefs.js:512
 msgid "Control how to change wallpapers automatically"
 msgstr ""
 
-#: src/prefs.js:506
+#: src/prefs.js:513
 msgid ""
 "\n"
 "    <b>Sequential:</b> Preserve the directory sequence (descending order).\n"
@@ -334,39 +342,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/prefs.js:513
+#: src/prefs.js:520
 msgid "Sequential"
 msgstr ""
 
-#: src/prefs.js:514
+#: src/prefs.js:521
 msgid "Inverse Sequential"
 msgstr ""
 
-#: src/prefs.js:515
+#: src/prefs.js:522
 msgid "Random"
 msgstr ""
 
-#: src/prefs.js:535
+#: src/prefs.js:542
 msgid "Bounds Inset"
 msgstr ""
 
-#: src/prefs.js:536
+#: src/prefs.js:543
 msgid ""
 "Adjust edges of the overview rounded-rect bounds (positive = shrink inward)"
 msgstr ""
 
-#: src/prefs.js:541
+#: src/prefs.js:548
 msgid "Left"
 msgstr ""
 
-#: src/prefs.js:542
+#: src/prefs.js:549
 msgid "Top"
 msgstr ""
 
-#: src/prefs.js:543
+#: src/prefs.js:550
 msgid "Right"
 msgstr ""
 
-#: src/prefs.js:544
+#: src/prefs.js:551
 msgid "Bottom"
 msgstr ""

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -63,6 +63,13 @@ export default class HanabiExtensionPreferences extends ExtensionPreferences {
             'show-panel-menu',
             ''
         );
+        prefsRowBoolean(
+            window,
+            generalGroup,
+            _('Show on Lock Screen'),
+            'show-on-lock-screen',
+            _('Show the live wallpaper on the lock screen')
+        );
 
         /**
          * Auto Pause

--- a/src/schemas/io.github.jeffshee.hanabi-extension.gschema.xml
+++ b/src/schemas/io.github.jeffshee.hanabi-extension.gschema.xml
@@ -140,6 +140,12 @@
             <description>Show the panel menu for the extension</description>
         </key>
 
+        <key name="show-on-lock-screen" type="b">
+            <default>true</default>
+            <summary>Show on Lock Screen</summary>
+            <description>Show the live wallpaper on the lock screen</description>
+        </key>
+
         <key name="corner-radius" type="i">
             <range min="0" max="100" />
             <default>30</default>


### PR DESCRIPTION
## Summary

- Adds a **Show on Lock Screen** toggle in General preferences (default: enabled)
- Adds `unlock-dialog` to `session-modes` so the extension stays active during lock screen
- Suspends the renderer subprocess when locked with the setting disabled, resuming on unlock

## Changes

- feat: show live wallpaper on lock screen