### PR TITLE
feat(ci): build and release installable extension zip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,11 +57,13 @@ jobs:
           echo "Packaged:"
           unzip -l "${GITHUB_WORKSPACE}/dist/${UUID}.shell-extension.zip"
 
+      # archive: false uploads the file as-is without GitHub's zip wrapper.
       - name: Upload zip artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ env.UUID }}.shell-extension
-          path: dist/*.shell-extension.zip
+          name: ${{ env.UUID }}.shell-extension.zip
+          path: dist/${{ env.UUID }}.shell-extension.zip
+          archive: false
           if-no-files-found: error
 
   # Separate job so write permission is granted only when publishing a release.
@@ -75,8 +77,10 @@ jobs:
       - name: Download zip artifact
         uses: actions/download-artifact@v8
         with:
-          name: ${{ env.UUID }}.shell-extension
+          name: ${{ env.UUID }}.shell-extension.zip
           path: dist
+          # Keep the .zip as-is; do not decompress the downloaded file.
+          skip-decompress: true
 
       - name: Attach zip to GitHub Release
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,84 @@
+name: Build extension zip
+
+on:
+  push:
+    branches: [typescript]
+    tags: ["v*"]
+  pull_request:
+    branches: [typescript]
+  workflow_dispatch:
+
+# Read by default. The release job below opts into write.
+permissions:
+  contents: read
+
+env:
+  UUID: hanabi-extension@jeffshee.github.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build gettext libglib2.0-bin
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build TypeScript sources
+        run: npm run build
+
+      - name: Assemble extension into a staging prefix
+        run: |
+          meson setup .build-ci --prefix=/usr
+          DESTDIR="${GITHUB_WORKSPACE}/staging" meson install -C .build-ci
+
+      - name: Package zip installable with `gnome-extensions install`
+        run: |
+          ext="${GITHUB_WORKSPACE}/staging/usr/share/gnome-shell/extensions/${UUID}"
+          # meson installs the gschema XML under the glib prefix; an installable
+          # zip needs the schema (compiled) inside the extension's own schemas/ dir.
+          mkdir -p "${ext}/schemas"
+          cp "${GITHUB_WORKSPACE}"/staging/usr/share/glib-2.0/schemas/*.gschema.xml "${ext}/schemas/"
+          glib-compile-schemas "${ext}/schemas/"
+          mkdir -p "${GITHUB_WORKSPACE}/dist"
+          ( cd "${ext}" && zip -qr "${GITHUB_WORKSPACE}/dist/${UUID}.shell-extension.zip" . )
+          echo "Packaged:"
+          unzip -l "${GITHUB_WORKSPACE}/dist/${UUID}.shell-extension.zip"
+
+      - name: Upload zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.UUID }}.shell-extension
+          path: dist/*.shell-extension.zip
+          if-no-files-found: error
+
+  # Separate job so write permission is granted only when publishing a release.
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download zip artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.UUID }}.shell-extension
+          path: dist
+
+      - name: Attach zip to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${GITHUB_REF_NAME}" dist/*.shell-extension.zip --generate-notes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: |
@@ -28,7 +28,7 @@ jobs:
           sudo apt-get install -y meson ninja-build gettext libglib2.0-bin
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -58,7 +58,7 @@ jobs:
           unzip -l "${GITHUB_WORKSPACE}/dist/${UUID}.shell-extension.zip"
 
       - name: Upload zip artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.UUID }}.shell-extension
           path: dist/*.shell-extension.zip
@@ -73,7 +73,7 @@ jobs:
       contents: write
     steps:
       - name: Download zip artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.UUID }}.shell-extension
           path: dist

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -17,6 +17,33 @@ Common development tasks are available via `make`:
 
 Run `make help` to see all available targets.
 
+## Release
+
+Pushing a `v*` tag triggers the [`build.yml`](../.github/workflows/build.yml)
+workflow, which builds the zip and publishes a GitHub Release with it attached.
+
+1. Bump `version:` in [`meson.build`](../meson.build) (a plain integer,
+   incremented by 1 — GNOME uses it to detect updates), commit, and merge.
+2. Tag the release commit and push:
+
+   ```bash
+   git tag -a v1.0.0 -m "Release 1.0.0"
+   git push origin v1.0.0
+   ```
+
+To re-cut, delete the tag (and its Release) first:
+
+```bash
+git tag -d v1.0.0                    # local
+git push origin :refs/tags/v1.0.0    # remote
+```
+
+Install the published zip with:
+
+```bash
+gnome-extensions install hanabi-extension@jeffshee.github.io.shell-extension.zip
+```
+
 ## License Headers
 
 License headers in `src/` are managed with [licensure](https://github.com/chasinglogic/licensure). Configuration is in [`.licensure.yml`](../.licensure.yml).


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that builds a zip installable with `gnome-extensions install`, with a release job that runs on `v*` tags
- Documents the release process in `docs/dev.md`

## Changes

- feat(ci): add workflow