### PR TITLE
Fix wallpaper misalignment in overview when corner radius > 0

### DIFF
--- a/src/wallpaper.ts
+++ b/src/wallpaper.ts
@@ -116,7 +116,7 @@ export const LiveWallpaper = GObject.registerClass(
             this.roundedCornersEffect = new RoundedCornersEffect();
             this.backgroundActor.add_effect(this.roundedCornersEffect);
 
-            this.setPixelStep(this.monitorWidth, this.monitorHeight);
+            this.setPixelStep(this.monitorWidth.width, this.monitorHeight.height);
             this.setRoundedClipRadius(0.0);
             this.setBorderStroke(0);
             this.setBorderColor([1.0, 0.0, 0.0, 1.0]);
@@ -135,12 +135,13 @@ export const LiveWallpaper = GObject.registerClass(
                     })
                 );
             }
-            this.setRoundedClipBounds(0, 0, this.monitorWidth, this.monitorHeight);
+            this.setRoundedClipBounds(0, 0, this.monitorWidth.width, this.monitorHeight.height);
 
             this.connect('notify::allocation', () => {
                 if (!this.wallpaper)
                     return;
                 try {
+                    this.setPixelStep(this.width, this.height);
                     this.applyBounds();
                     const stroke = this.settings.get_int('border-stroke');
                     this.roundedCornersEffect.setBorderStroke(stroke * this.monitorScale);

--- a/src/wallpaper.ts
+++ b/src/wallpaper.ts
@@ -116,7 +116,7 @@ export const LiveWallpaper = GObject.registerClass(
             this.roundedCornersEffect = new RoundedCornersEffect();
             this.backgroundActor.add_effect(this.roundedCornersEffect);
 
-            this.setPixelStep(this.monitorWidth.width, this.monitorHeight.height);
+            this.setPixelStep(this.monitorWidth, this.monitorHeight);
             this.setRoundedClipRadius(0.0);
             this.setBorderStroke(0);
             this.setBorderColor([1.0, 0.0, 0.0, 1.0]);
@@ -135,7 +135,7 @@ export const LiveWallpaper = GObject.registerClass(
                     })
                 );
             }
-            this.setRoundedClipBounds(0, 0, this.monitorWidth.width, this.monitorHeight.height);
+            this.setRoundedClipBounds(0, 0, this.monitorWidth, this.monitorHeight);
 
             this.connect('notify::allocation', () => {
                 if (!this.wallpaper)


### PR DESCRIPTION
RoundedCornersEffect's pixel_step was derived from the physical monitor resolution (Main.layoutManager.monitors) instead of the actual size of the background actor the effect is attached to.

This is a no-op for the real desktop background, which happens to match the monitor's resolution, but GNOME also creates smaller background actors for workspace previews/thumbnails in the overview, where backgroundActor.width/height is much smaller than the monitor.

With corner radius 0 the mismatch is invisible since there's no rounding to distort; with radius > 0 the shader's pixel_step no longer matches the coordinate space bounds is expressed in, misaligning the rounded clip relative to the actual overview background.

Derive pixel_step from backgroundActor's own size at construction, and recompute it on every allocation change alongside the existing bounds recalculation, mirroring how bounds already handles actor-size changes.

Fixes #239