### PR TITLE
feat: recognize the Hotaru renderer's window-title protocol

### DIFF
--- a/src/autoPause.ts
+++ b/src/autoPause.ts
@@ -25,7 +25,7 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import {Logger} from './logger.js';
 import {DBusWrapper, MprisWrapper, UPowerWrapper} from './dbus.js';
-import {APPLICATION_ID} from './constants.js';
+import {isRendererTitle} from './constants.js';
 import type {PlaybackState} from './playbackState.js';
 import type HanabiExtension from './extension.js';
 
@@ -184,7 +184,7 @@ const PauseOnMaximizeOrFullscreenModule = GObject.registerClass(
         }
 
         private onWindowAdded(metaWindow: Meta.Window, doUpdate = true): void {
-            if (metaWindow.title?.includes(APPLICATION_ID) || metaWindow.skip_taskbar)
+            if (isRendererTitle(metaWindow.title) || metaWindow.skip_taskbar)
                 return;
 
             const signals: number[] = [];
@@ -211,7 +211,7 @@ const PauseOnMaximizeOrFullscreenModule = GObject.registerClass(
         }
 
         private onWindowRemoved(metaWindow: Meta.Window): void {
-            if (metaWindow.title?.includes(APPLICATION_ID) || metaWindow.skip_taskbar)
+            if (isRendererTitle(metaWindow.title) || metaWindow.skip_taskbar)
                 return;
 
             this.windows = this.windows.filter(window => {
@@ -264,7 +264,7 @@ const PauseOnMaximizeOrFullscreenModule = GObject.registerClass(
         override update(): void {
             const metaWindows = this.windows
                 .map(({metaWindow}) => metaWindow)
-                .filter(w => !w.title?.includes(APPLICATION_ID) && !w.minimized);
+                .filter(w => !isRendererTitle(w.title) && !w.minimized);
 
             const monitors = Main.layoutManager.monitors;
 
@@ -393,7 +393,7 @@ const PauseOnFocusModule = GObject.registerClass(
                 focusWindow !== undefined &&
                 focusWindow.appears_focused &&
                 !focusWindow.minimized &&
-                !(focusWindow.title?.includes(APPLICATION_ID) ?? false) &&
+                !isRendererTitle(focusWindow.title) &&
                 !focusWindow.skip_taskbar;
 
             this.logger.debug(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,3 +22,18 @@ export const APPLICATION_ID = 'io.github.jeffshee.HanabiRenderer';
 
 // The renderer's D-Bus object path, derived from APPLICATION_ID.
 export const RENDERER_OBJECT_PATH = `/${APPLICATION_ID.replaceAll('.', '/')}`;
+
+// The external Hotaru renderer's application id, used in its window-title
+// protocol (`@<id>!<params json>`, see windowManager.ts). Must match
+// hotaru's APPLICATION_ID constant.
+export const HOTARU_APPLICATION_ID = 'io.github.jeffshee.Hotaru';
+
+// Whether a window title identifies a renderer (wallpaper) window —
+// either the built-in renderer or Hotaru.
+export function isRendererTitle(title?: string | null): boolean {
+    return Boolean(
+        title &&
+            (title.includes(APPLICATION_ID) ||
+                title.includes(HOTARU_APPLICATION_ID))
+    );
+}

--- a/src/windowManager.ts
+++ b/src/windowManager.ts
@@ -21,7 +21,7 @@ import Meta from 'gi://Meta';
 import Shell from 'gi://Shell';
 
 import {Logger} from './logger.js';
-import {APPLICATION_ID} from './constants.js';
+import {APPLICATION_ID, HOTARU_APPLICATION_ID} from './constants.js';
 import type {WaylandSubprocess} from './waylandSubprocess.js';
 
 const logger = new Logger('windowManager');
@@ -31,6 +31,16 @@ interface WindowState {
     keepAtBottom: boolean;
     keepMinimized: boolean;
     keepPosition: boolean;
+}
+
+// Hotaru's compact window-title params: p = position, b = keep at bottom,
+// m = keep minimized, k = keep position. Must match hotaru's HanabiParams
+// serialization.
+interface HotaruWindowState {
+    p: [number, number];
+    b: boolean;
+    m: boolean;
+    k: boolean;
 }
 
 interface ManagedMetaWindow extends Meta.Window {
@@ -113,7 +123,22 @@ class ManagedWindow {
 
     private parseTitle(): void {
         const title = this.window.title;
-        if (title?.startsWith(`@${APPLICATION_ID}!`)) {
+        if (title?.startsWith(`@${HOTARU_APPLICATION_ID}!`)) {
+            const json = title
+                .replace(`@${HOTARU_APPLICATION_ID}!`, '')
+                .split('|')[0];
+            try {
+                const v2 = JSON.parse(json) as Partial<HotaruWindowState>;
+                this.states = {
+                    position: v2.p ?? this.states.position,
+                    keepAtBottom: v2.b ?? this.states.keepAtBottom,
+                    keepMinimized: v2.m ?? this.states.keepMinimized,
+                    keepPosition: v2.k ?? this.states.keepPosition,
+                };
+            } catch (e) {
+                logger.trace(e);
+            }
+        } else if (title?.startsWith(`@${APPLICATION_ID}!`)) {
             const json = title.replace(`@${APPLICATION_ID}!`, '').split('|')[0];
             try {
                 const newState = JSON.parse(json) as Partial<WindowState>;


### PR DESCRIPTION
## Summary

Counterpart to jeffshee/hotaru#2. Hotaru now identifies its wallpaper windows with its own application id and a compact title payload:

```
@io.github.jeffshee.Hotaru!{"p":[x,y],"b":true,"m":true,"k":true}
```

(`p` position, `b` keep-at-bottom, `m` keep-minimized, `k` keep-position — hotaru's `HanabiParams` serialization.)

- `windowManager.ts` parses the Hotaru protocol alongside the built-in renderer's legacy format (`@io.github.jeffshee.HanabiRenderer!{"position":…}` keeps working).
- `autoPause.ts` identifies renderer windows via a shared `isRendererTitle()` helper matching either application id.
- New `HOTARU_APPLICATION_ID` constant documents the cross-repo contract.

⚠️ Ships in lockstep with jeffshee/hotaru#2 — hotaru builds after that PR emit only the new format.

## Test plan
- `npm run typecheck`, `npm run lint`, `npm run build` all clean.
- Legacy path unchanged (fallback branch is the previous code verbatim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)