### PR TITLE
Fix renderer actor teardown race

### DIFF
--- a/src/gnomeShellOverride.ts
+++ b/src/gnomeShellOverride.ts
@@ -38,10 +38,7 @@ const logger = new Logger('override');
 const BACKGROUND_RELOAD_REFRESH_DELAY_MS = 500;
 
 export class GnomeShellOverride {
-    // Method patching, plus the original get_window_actors captured from our override of it
-    // (the override hides renderer windows, so LiveWallpaper uses this to still find them).
     private injectionManager = new InjectionManager();
-    private getAllWindowActors: () => Meta.WindowActor[] = () => global.get_window_actors();
 
     // Live wallpaper actors we've injected.
     private wallpaperActors = new Set<LiveWallpaper>();
@@ -123,8 +120,7 @@ export class GnomeShellOverride {
                     logger.debug(`Injecting live wallpaper (monitor ${backgroundActor.monitor})`);
                     this.wallpaperActor = new LiveWallpaper(
                         backgroundActor as Meta.BackgroundActor,
-                        thisRef.settings,
-                        thisRef.getAllWindowActors
+                        thisRef.settings
                     );
                     thisRef.wallpaperActors.add(this.wallpaperActor);
 
@@ -172,11 +168,13 @@ export class GnomeShellOverride {
             Shell.Global.prototype,
             'get_window_actors',
             originalMethod => {
-                thisRef.getAllWindowActors = () => originalMethod.call(global);
-                return function (this: Shell.Global) {
-                    return originalMethod.call(this).filter(
-                        actor => !actor.meta_window?.title?.includes(APPLICATION_ID)
-                    );
+                return function (this: Shell.Global, hideRenderer = true) {
+                    const windowActors = originalMethod.call(this);
+                    return hideRenderer
+                        ? windowActors.filter(
+                            actor => !actor.meta_window?.title?.includes(APPLICATION_ID)
+                        )
+                        : windowActors;
                 };
             }
         );

--- a/src/wallpaper.ts
+++ b/src/wallpaper.ts
@@ -43,11 +43,7 @@ export const LiveWallpaper = GObject.registerClass(
         private metaBackgroundGroup: Clutter.Actor | null;
         private monitorIndex: number;
 
-        // Injected dependencies.
         private settings: Gio.Settings;
-        // Returns all window actors unfiltered (renderer windows are hidden from the
-        // public get_window_actors by GnomeShellOverride); injected so getRenderer can find them.
-        private getWindowActors: () => Meta.WindowActor[];
 
         // Lifecycle bookkeeping, cleaned up on destroy.
         private isDisposed = false;
@@ -67,8 +63,7 @@ export const LiveWallpaper = GObject.registerClass(
 
         constructor(
             backgroundActor: Meta.BackgroundActor,
-            settings: Gio.Settings,
-            getWindowActors: () => Meta.WindowActor[]
+            settings: Gio.Settings
         ) {
             super({
                 layout_manager: new Clutter.BinLayout(),
@@ -82,7 +77,6 @@ export const LiveWallpaper = GObject.registerClass(
             this.metaBackgroundGroup = backgroundActor.get_parent();
             this.monitorIndex = this.backgroundActor.monitor;
             this.settings = settings;
-            this.getWindowActors = getWindowActors;
 
             this.connect('destroy', () => {
                 this.isDisposed = true;
@@ -228,10 +222,20 @@ export const LiveWallpaper = GObject.registerClass(
                     this.sourceDestroyId = this.wallpaper.source!.connect(
                         'destroy',
                         () => {
+                            this.sourceDestroyId = null;
                             if (this.wallpaper)
                                 this.wallpaper.destroy();
-                            if (!this.isDisposed)
-                                this.applyWallpaper();
+                            if (!this.isDisposed && !this.rendererPollTimeoutId) {
+                                this.rendererPollTimeoutId = GLib.timeout_add(
+                                    GLib.PRIORITY_DEFAULT,
+                                    RENDERER_POLL_INTERVAL_MS,
+                                    () => {
+                                        this.rendererPollTimeoutId = 0;
+                                        this.applyWallpaper();
+                                        return GLib.SOURCE_REMOVE;
+                                    }
+                                );
+                            }
                         }
                     );
                     this.add_child(this.wallpaper);
@@ -254,9 +258,11 @@ export const LiveWallpaper = GObject.registerClass(
         }
 
         private getRenderer(): Clutter.Actor | null {
-            // Renderer windows are hidden from the public get_window_actors, so use the
-            // injected unfiltered accessor to find them.
-            const hanabiWindowActors = this.getWindowActors().filter(
+            // Pass false to bypass Hanabi's renderer-window filter while the override is active.
+            // After teardown, GNOME's original method safely ignores the extra argument.
+            const getWindowActors = global.get_window_actors as
+                (hideRenderer?: boolean) => Meta.WindowActor[];
+            const hanabiWindowActors = getWindowActors.call(global, false).filter(
                 actor => actor.meta_window?.title?.includes(APPLICATION_ID)
             );
 


### PR DESCRIPTION
## Summary

- avoid retaining `InjectionManager`'s temporary original `get_window_actors` method after overrides are cleared
- expose an explicit `hideRenderer = false` bypass while the override is active
- defer wallpaper recreation until after the renderer source actor finishes destruction

## User impact

After an idle lock/unlock cycle, opening Activities with Super could leave GNOME Shell on a gray overview that ignored keyboard input while the top bar remained responsive. Logging out recovered the session.

Environment where this was reproduced:

- Ubuntu 26.04
- GNOME Shell 50.1
- Wayland
- TypeScript-branch extension bundle, version 1

The journal showed:

```text
JS ERROR: TypeError: can't access property 0, replaceData.old_get_window_actors is undefined
... LiveWallpaper.getRenderer
... LiveWallpaper.applyWallpaper
```

It was followed by a GJS warning about calling back into JSAPI during GC while destroying a `LiveWallpaper` actor.

## Root cause

`GnomeShellOverride` captured the `originalMethod` supplied by `InjectionManager` and passed a closure around it into each `LiveWallpaper`. Once `InjectionManager.clear()` removed its replacement data, an asynchronous wallpaper callback could still invoke that stale closure.

The renderer source's `destroy` callback also called `applyWallpaper()` synchronously while Clutter was still tearing down the actor graph. That made the stale-method race more likely and attempted to clone a replacement source during destruction.

## Fix

The overridden method now accepts an optional `hideRenderer` argument. `LiveWallpaper` calls the current method with `false` when it needs the unfiltered actor list. While Hanabi is active, this bypasses its filter; after teardown, GNOME's original method safely ignores the extra argument.

Renderer recovery is scheduled one polling interval after source destruction. The existing disposal path cancels that timeout if the wallpaper actor is destroyed first.

This is related to the lifecycle and DING symptoms discussed in #212 and the lock/unlock failure in #241, but does not skip the renderer-window filter or require DING to be enabled.

## Validation

- reproduced the original stack trace from the released TypeScript bundle
- applied the generated equivalent locally and verified GNOME reports no extension load errors
- `npm run typecheck`
- `npm run build`
- `npm run lint -- src/gnomeShellOverride.ts src/wallpaper.ts`
- `git diff --check`
