### PR TITLE
fix: accurate calculation for rounded corners effect

### DIFF
--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -93,7 +93,6 @@ export default class HanabiExtensionPreferences extends ExtensionPreferences {
             0, 10000, 100, 500);
         prefsRowInt(win, developerGroup, _('Border Stroke'), 'border-stroke',
             _('Border width in pixels drawn inside the rounded-rect bounds (0 = disabled)'), 0, 20, 1, 1);
-        prefsRowBoundsInset(win, developerGroup);
 
         window.add(page);
         return Promise.resolve();
@@ -353,30 +352,3 @@ function prefsRowChangeWallpaperMode(
     });
 }
 
-function prefsRowBoundsInset(window: PrefsWindow, prefsGroup: Adw.PreferencesGroup): void {
-    const settings = window.settings;
-    const expander = new Adw.ExpanderRow({
-        title: _('Bounds Inset'),
-        subtitle: _('Adjust edges of the overview rounded-rect bounds (positive = shrink inward)'),
-    });
-    prefsGroup.add(expander);
-
-    for (const [title, key] of [
-        [_('Left'), 'bounds-inset-x1'],
-        [_('Top'), 'bounds-inset-y1'],
-        [_('Right'), 'bounds-inset-x2'],
-        [_('Bottom'), 'bounds-inset-y2'],
-    ] as [string, string][]) {
-        const child = new Adw.ActionRow({title});
-        const adjustment = new Gtk.Adjustment({
-            lower: -200,
-            upper: 200,
-            step_increment: 1,
-            page_increment: 10,
-            value: settings.get_int(key),
-        });
-        adjustment.connect('value-changed', () => settings.set_int(key, adjustment.value));
-        child.add_suffix(new Gtk.SpinButton({adjustment, valign: Gtk.Align.CENTER}));
-        expander.add_row(child);
-    }
-}

--- a/src/roundedCornersEffect.ts
+++ b/src/roundedCornersEffect.ts
@@ -15,6 +15,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import Clutter from 'gi://Clutter';
 import Cogl from 'gi://Cogl';
 import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
@@ -102,10 +103,64 @@ const fragmentShaderCode = [
     '    cogl_color_out *= rounded_rect_coverage (texture_coord);             \n',
 ].join('');
 
+// Port of mutter's _clutter_actor_box_enlarge_for_effects: the stable, padded
+// quantization applied to the paint box before it becomes the offscreen
+// texture. Returns the enlarged box origin.
+function enlargeForEffects(
+    x1: number,
+    y1: number,
+    width: number,
+    height: number
+): [number, number] {
+    if (width <= 0 || height <= 0)
+        return [x1, y1];
+    const x2 = Math.ceil(x1 + width + 0.75);
+    const y2 = Math.ceil(y1 + height + 0.75);
+    return [x2 - Math.round(width) - 3, y2 - Math.round(height) - 3];
+}
+
+// Replicates ClutterOffscreenEffect's fbo_offset: the offscreen texture's
+// origin in actor-local coordinates, typically (-2, -2). See
+// clutter_offscreen_effect_pre_paint in clutter-offscreen-effect.c.
+function getFboOffset(actor: Clutter.Actor): [number, number] {
+    const volume = actor.get_paint_volume();
+    if (volume) {
+        const origin = volume.get_origin();
+        const [x1, y1] = enlargeForEffects(
+            origin.x,
+            origin.y,
+            volume.get_width(),
+            volume.get_height()
+        );
+        return [Math.trunc(x1), Math.trunc(y1)];
+    }
+    const box = actor.get_allocation_box();
+    const [x1, y1] = enlargeForEffects(
+        box.x1,
+        box.y1,
+        box.x2 - box.x1,
+        box.y2 - box.y1
+    );
+    return [Math.trunc(x1 - box.x1), Math.trunc(y1 - box.y1)];
+}
+
 export const RoundedCornersEffect = GObject.registerClass(
     class RoundedCornersEffect extends Shell.GLSLEffect {
         // Pending debounced log timers, keyed by label.
         private logTimeouts = new Map<string, number>();
+
+        // Uniform values in actor-local logical pixels, as set by callers.
+        private bounds = [0, 0, 0, 0];
+        private clipRadius = 0;
+        private borderStroke = 0;
+        private uniformsDirty = true;
+
+        // Actor-to-texture mapping the uniforms were last uploaded for.
+        private textureWidth = 0;
+        private textureHeight = 0;
+        private textureScale = 0;
+        private textureOffsetX = 0;
+        private textureOffsetY = 0;
 
         // Logs `label: ...args` only once the value stops changing for LOG_DEBOUNCE_MS.
         private debugDebounced(label: string, ...args: unknown[]): void {
@@ -131,40 +186,93 @@ export const RoundedCornersEffect = GObject.registerClass(
             );
         }
 
-        setBounds(bounds: number[]): void {
-            this.debugDebounced('bounds', ...bounds);
+        // The shader compares texture coordinates (converted to texture pixels
+        // via pixel_step) against bounds/clip_radius/border_stroke, so those
+        // uniforms must be expressed in pixels of the offscreen texture this
+        // effect renders into. mutter sizes that texture from the actor's paint
+        // box, not its allocation, and the relation between the two varies
+        // across mutter versions (e.g. Clutter.Clone paint volumes changed in
+        // 50.2, commit d26ac38b) and monitor scales (the texture uses the
+        // ceiled resource scale). Instead of predicting the size, read the
+        // actual texture at paint time and mirror mutter's actor-to-texture
+        // mapping: texture_px = (logical_px - fbo_offset) * resource_scale.
+        vfunc_paint_target(node: Clutter.PaintNode, paintContext: Clutter.PaintContext): void {
+            this.updateUniforms();
+            super.vfunc_paint_target(node, paintContext);
+        }
+
+        private updateUniforms(): void {
+            const texture = this.get_texture();
+            const actor = this.get_actor();
+            if (!texture || !actor)
+                return;
+
+            const width = texture.get_width();
+            const height = texture.get_height();
+            // The same ceiled scale mutter uses to size and paint the texture.
+            const scale = actor.get_resource_scale();
+            const [offsetX, offsetY] = getFboOffset(actor);
+
+            if (!this.uniformsDirty &&
+                width === this.textureWidth &&
+                height === this.textureHeight &&
+                scale === this.textureScale &&
+                offsetX === this.textureOffsetX &&
+                offsetY === this.textureOffsetY)
+                return;
+
+            this.uniformsDirty = false;
+            this.textureWidth = width;
+            this.textureHeight = height;
+            this.textureScale = scale;
+            this.textureOffsetX = offsetX;
+            this.textureOffsetY = offsetY;
+            this.debugDebounced('textureMapping', width, height, scale, offsetX, offsetY);
+
+            this.set_uniform_float(
+                this.get_uniform_location('pixel_step'),
+                2,
+                [1.0 / width, 1.0 / height]
+            );
+            const [x1, y1, x2, y2] = this.bounds;
             this.set_uniform_float(
                 this.get_uniform_location('bounds'),
                 4,
-                bounds
+                [
+                    (x1 - offsetX) * scale,
+                    (y1 - offsetY) * scale,
+                    (x2 - offsetX) * scale,
+                    (y2 - offsetY) * scale,
+                ]
             );
+            this.set_uniform_float(
+                this.get_uniform_location('clip_radius'),
+                1,
+                [this.clipRadius * scale]
+            );
+            this.set_uniform_float(
+                this.get_uniform_location('border_stroke'),
+                1,
+                [this.borderStroke * scale]
+            );
+        }
+
+        setBounds(bounds: number[]): void {
+            this.debugDebounced('bounds', ...bounds);
+            this.bounds = bounds;
+            this.uniformsDirty = true;
         }
 
         setClipRadius(clipRadius: number): void {
             this.debugDebounced('clipRadius', clipRadius);
-            this.set_uniform_float(
-                this.get_uniform_location('clip_radius'),
-                1,
-                [clipRadius]
-            );
-        }
-
-        setPixelStep(pixelStep: number[]): void {
-            this.debugDebounced('pixelStep', ...pixelStep);
-            this.set_uniform_float(
-                this.get_uniform_location('pixel_step'),
-                2,
-                pixelStep
-            );
+            this.clipRadius = clipRadius;
+            this.uniformsDirty = true;
         }
 
         setBorderStroke(stroke: number): void {
             this.debugDebounced('borderStroke', stroke);
-            this.set_uniform_float(
-                this.get_uniform_location('border_stroke'),
-                1,
-                [stroke]
-            );
+            this.borderStroke = stroke;
+            this.uniformsDirty = true;
         }
 
         setBorderColor(color: number[]): void {

--- a/src/schemas/io.github.jeffshee.hanabi-extension.gschema.xml
+++ b/src/schemas/io.github.jeffshee.hanabi-extension.gschema.xml
@@ -160,32 +160,5 @@
             <description>Border width in pixels drawn inside the rounded-rect bounds (0 = disabled)</description>
         </key>
 
-        <key name="bounds-inset-x1" type="i">
-            <range min="-200" max="200" />
-            <default>2</default>
-            <summary>Bounds Inset (Left)</summary>
-            <description>Additional inset for the left edge of the rounded-rect bounds (positive = move inward)</description>
-        </key>
-
-        <key name="bounds-inset-y1" type="i">
-            <range min="-200" max="200" />
-            <default>2</default>
-            <summary>Bounds Inset (Top)</summary>
-            <description>Additional inset for the top edge of the rounded-rect bounds (positive = move inward)</description>
-        </key>
-
-        <key name="bounds-inset-x2" type="i">
-            <range min="-200" max="200" />
-            <default>2</default>
-            <summary>Bounds Inset (Right)</summary>
-            <description>Additional inset for the right edge of the rounded-rect bounds (positive = move inward)</description>
-        </key>
-
-        <key name="bounds-inset-y2" type="i">
-            <range min="-200" max="200" />
-            <default>2</default>
-            <summary>Bounds Inset (Bottom)</summary>
-            <description>Additional inset for the bottom edge of the rounded-rect bounds (positive = move inward)</description>
-        </key>
     </schema>
 </schemalist>

--- a/src/wallpaper.ts
+++ b/src/wallpaper.ts
@@ -124,15 +124,7 @@ export const LiveWallpaper = GObject.registerClass(
             );
             this.setRoundedClipBounds(0, 0, this.monitorWidth, this.monitorHeight);
 
-            this.connect('notify::allocation', () => {
-                if (!this.wallpaper)
-                    return;
-                try {
-                    this.applyBounds();
-                } catch (e) {
-                    logError(e as object, 'LiveWallpaper notify::allocation');
-                }
-            });
+            this.connect('notify::allocation', () => this.applyBounds());
 
             this.applyWallpaper();
         }
@@ -143,8 +135,10 @@ export const LiveWallpaper = GObject.registerClass(
         }
 
         private applyBounds(): void {
-            const workArea = Main.layoutManager.getWorkAreaForMonitor(this.monitorIndex);
             const monitor = Main.layoutManager.monitors[this.monitorIndex];
+            if (!monitor)
+                return;
+            const workArea = Main.layoutManager.getWorkAreaForMonitor(this.monitorIndex);
             const panelOffset = (workArea.y - monitor.y) / monitor.height * this.backgroundActor.height;
             this.roundedCornersEffect.setBounds(
                 [0, panelOffset, this.width, this.height]

--- a/src/wallpaper.ts
+++ b/src/wallpaper.ts
@@ -60,8 +60,6 @@ export const LiveWallpaper = GObject.registerClass(
 
         // Rendering effect and monitor geometry, set up in the constructor.
         private roundedCornersEffect!: RoundedCornersEffect;
-        private display!: Meta.Display;
-        private monitorScale!: number;
         private monitorWidth!: number;
         private monitorHeight!: number;
 
@@ -104,8 +102,6 @@ export const LiveWallpaper = GObject.registerClass(
                 }
             });
 
-            this.display = this.backgroundActor.meta_display;
-            this.monitorScale = this.display.get_monitor_scale(this.monitorIndex);
             const {width, height} = Main.layoutManager.monitors[this.monitorIndex];
             this.monitorWidth = width;
             this.monitorHeight = height;
@@ -116,9 +112,8 @@ export const LiveWallpaper = GObject.registerClass(
             this.roundedCornersEffect = new RoundedCornersEffect();
             this.backgroundActor.add_effect(this.roundedCornersEffect);
 
-            this.setPixelStep(this.monitorWidth, this.monitorHeight);
             this.setRoundedClipRadius(0.0);
-            this.setBorderStroke(0);
+            this.setBorderStroke(this.settings.get_int('border-stroke'));
             this.setBorderColor([1.0, 0.0, 0.0, 1.0]);
 
             this.settingsChangedIds.push(
@@ -127,24 +122,13 @@ export const LiveWallpaper = GObject.registerClass(
                     this.backgroundActor?.queue_redraw();
                 })
             );
-            for (const key of ['bounds-inset-x1', 'bounds-inset-y1', 'bounds-inset-x2', 'bounds-inset-y2']) {
-                this.settingsChangedIds.push(
-                    this.settings.connect(`changed::${key}`, () => {
-                        this.applyBounds();
-                        this.backgroundActor?.queue_redraw();
-                    })
-                );
-            }
             this.setRoundedClipBounds(0, 0, this.monitorWidth, this.monitorHeight);
 
             this.connect('notify::allocation', () => {
                 if (!this.wallpaper)
                     return;
                 try {
-                    this.setPixelStep(this.width, this.height);
                     this.applyBounds();
-                    const stroke = this.settings.get_int('border-stroke');
-                    this.roundedCornersEffect.setBorderStroke(stroke * this.monitorScale);
                 } catch (e) {
                     logError(e as object, 'LiveWallpaper notify::allocation');
                 }
@@ -162,37 +146,21 @@ export const LiveWallpaper = GObject.registerClass(
             const workArea = Main.layoutManager.getWorkAreaForMonitor(this.monitorIndex);
             const monitor = Main.layoutManager.monitors[this.monitorIndex];
             const panelOffset = (workArea.y - monitor.y) / monitor.height * this.backgroundActor.height;
-            const ix1 = this.settings.get_int('bounds-inset-x1');
-            const iy1 = this.settings.get_int('bounds-inset-y1');
-            const ix2 = this.settings.get_int('bounds-inset-x2');
-            const iy2 = this.settings.get_int('bounds-inset-y2');
             this.roundedCornersEffect.setBounds(
-                [ix1, panelOffset + iy1, this.width - ix2, this.height - iy2]
-                    .map(e => e * this.monitorScale)
+                [0, panelOffset, this.width, this.height]
             );
-        }
-
-        setPixelStep(width: number, height: number): void {
-            if (this.isDisposed)
-                return;
-            this.roundedCornersEffect.setPixelStep([
-                1.0 / (width * this.monitorScale),
-                1.0 / (height * this.monitorScale),
-            ]);
         }
 
         setRoundedClipRadius(radius: number): void {
             if (this.isDisposed)
                 return;
-            this.roundedCornersEffect.setClipRadius(radius * this.monitorScale);
+            this.roundedCornersEffect.setClipRadius(radius);
         }
 
         setRoundedClipBounds(x1: number, y1: number, x2: number, y2: number): void {
             if (this.isDisposed)
                 return;
-            this.roundedCornersEffect.setBounds(
-                [x1, y1, x2, y2].map(e => e * this.monitorScale)
-            );
+            this.roundedCornersEffect.setBounds([x1, y1, x2, y2]);
         }
 
         setBorderStroke(stroke: number): void {


### PR DESCRIPTION
## Summary

The correct `pixel_step` for the rounded corners effect depends on how mutter sizes the offscreen texture, which varies across mutter versions (`Clutter.Clone` paint volume changed in 50.2, d26ac38b) and monitor scales. Instead of guessing from JS, derive the actor-to-texture mapping from ground truth at paint time: texture size, resource scale, and fbo offset. Bounds are now exact on all mutter versions in GNOME 50, so the bounds-inset workaround is removed.

## Changes

- fix: accurate calculation for rounded corners effect
- refactor: replace blanket try/catch with monitor guard in applyBounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)