### PR TITLE
fix: hidden top bar

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,8 +96,6 @@ export default class HanabiExtension extends Extension {
             const startupCompleteId = Main.layoutManager.connect(
                 'startup-complete',
                 () => {
-                    // Issue #65: don't open the overview at login.
-                    Main.overview.hide();
                     GLib.timeout_add(
                         GLib.PRIORITY_DEFAULT,
                         this.settings!.get_int('startup-delay'),

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -91,7 +91,6 @@ let changeWallpaperMode = extSettings?.get_int('change-wallpaper-mode') ?? 0;
 let changeWallpaperInterval = extSettings?.get_int('change-wallpaper-interval') ?? 15;
 let windowDimension = {width: 1920, height: 1080};
 let windowed = false;
-const fullscreened = true;
 let isDebugMode = extSettings?.get_boolean('debug-mode') ?? true;
 let changeWallpaperTimerId: number | null = null;
 
@@ -112,12 +111,9 @@ const HanabiRendererWindow = GObject.registerClass(
             );
             this.set_child(widget);
             if (!windowed) {
-                if (fullscreened) {
-                    this.fullscreen_on_monitor(gdkMonitor);
-                } else {
-                    const geometry = gdkMonitor.get_geometry();
-                    this.set_size_request(geometry.width, geometry.height);
-                }
+                const geometry = gdkMonitor.get_geometry();
+                this.set_size_request(geometry.width, geometry.height);
+                this.set_resizable(false);
             }
         }
     }
@@ -381,8 +377,8 @@ const HanabiRenderer = GObject.registerClass(
                 const window = new HanabiRendererWindow({
                     application: this,
                     decorated: !!nohide,
-                    default_height: windowDimension.height,
-                    default_width: windowDimension.width,
+                    default_height: windowed ? windowDimension.height : geometry.height,
+                    default_width: windowed ? windowDimension.width : geometry.width,
                     title: windowTitle,
                 });
                 window._setup(widget, gdkMonitor);

--- a/src/windowManager.ts
+++ b/src/windowManager.ts
@@ -17,14 +17,19 @@
 
 // Adapted from ManageWindow and EmulateX11WindowType in the DING extension.
 
+import GLib from 'gi://GLib';
 import Meta from 'gi://Meta';
 import Shell from 'gi://Shell';
+import type Clutter from 'gi://Clutter';
 
 import {Logger} from './logger.js';
 import {APPLICATION_ID} from './constants.js';
 import type {WaylandSubprocess} from './waylandSubprocess.js';
 
 const logger = new Logger('windowManager');
+
+// Delay before verifying that a keep-minimized window actually got hidden (ms).
+const MINIMIZE_RESYNC_DELAY_MS = 250;
 
 interface WindowState {
     position: [number, number];
@@ -49,6 +54,7 @@ class ManagedWindow {
     };
 
     private isDisposed = false;
+    private resyncTimeoutId = 0;
 
     constructor(window: Meta.Window) {
         this.window = window;
@@ -65,8 +71,10 @@ class ManagedWindow {
             window.connect_after('shown', () => {
                 if (this.isDisposed)
                     return;
-                if (this.states.keepMinimized)
+                if (this.states.keepMinimized) {
                     this.window.minimize();
+                    this.scheduleMinimizeResync();
+                }
             })
         );
 
@@ -125,11 +133,38 @@ class ManagedWindow {
         this.refresh();
     }
 
+    // After wake from suspend, a window can stay visible (and clickable) even
+    // though mutter already considers it minimized, so minimize() alone does
+    // nothing. Since mutter hides windows asynchronously, check again shortly
+    // after: if the window is still visible, unminimize + minimize to force
+    // mutter to actually hide it.
+    private scheduleMinimizeResync(): void {
+        if (this.resyncTimeoutId)
+            return;
+        this.resyncTimeoutId = GLib.timeout_add(
+            GLib.PRIORITY_DEFAULT,
+            MINIMIZE_RESYNC_DELAY_MS,
+            () => {
+                this.resyncTimeoutId = 0;
+                if (this.isDisposed || !this.states.keepMinimized)
+                    return GLib.SOURCE_REMOVE;
+                const actor = this.window.get_compositor_private() as Clutter.Actor | null;
+                if (this.window.minimized && actor?.visible) {
+                    logger.debug('Minimized window still mapped, forcing resync');
+                    this.window.unminimize();
+                    this.window.minimize();
+                }
+                return GLib.SOURCE_REMOVE;
+            }
+        );
+    }
+
     private refresh(): void {
         if (this.states.keepAtBottom && this.window.above)
             this.window.unmake_above();
         if (this.states.keepMinimized && !this.window.minimized)
             this.window.minimize();
+        this.scheduleMinimizeResync();
         if (this.states.keepPosition) {
             const [x, y] = this.states.position;
             this.window.move_frame(true, x, y);
@@ -138,6 +173,10 @@ class ManagedWindow {
 
     disconnect(): void {
         this.isDisposed = true;
+        if (this.resyncTimeoutId) {
+            GLib.source_remove(this.resyncTimeoutId);
+            this.resyncTimeoutId = 0;
+        }
         this.signals.forEach(signal => this.window.disconnect(signal));
     }
 }


### PR DESCRIPTION
## Summary

After wake from suspend, mutter can leave the renderer window mapped while its minimized flag is still set. Since the window was a real fullscreen window, GNOME Shell hid the top bar, and clicks on the wallpaper landed on the invisible window (same mechanism as #65).

- Use a fixed monitor-sized window instead of fullscreen, so the renderer can never trigger the top bar hiding.
- Detect the mapped-but-minimized desync after a renderer window is shown and force a visibility resync.
- Remove the `Main.overview.hide()` login workaround from #65, no longer needed.

Fixes #251 

## Changes

- fix: schedule minimize resync

🤖 Generated with [Claude Code](https://claude.com/claude-code)
