### PR TITLE
fix: bypass pause on maximize or fullscreen during overview or lockscreen

### DIFF
--- a/src/autoPause.ts
+++ b/src/autoPause.ts
@@ -136,6 +136,7 @@ const PauseOnMaximizeOrFullscreenModule = GObject.registerClass(
         private overviewShowingId: number | null;
         private overviewHiddenId: number | null;
         private sessionModeUpdatedId: number | null;
+        private showingDesktopChangedId: number | null;
 
         constructor(settings: Gio.Settings) {
             super(settings, 'maximizeOrFullscreen');
@@ -168,6 +169,7 @@ const PauseOnMaximizeOrFullscreenModule = GObject.registerClass(
             this.overviewShowingId = null;
             this.overviewHiddenId = null;
             this.sessionModeUpdatedId = null;
+            this.showingDesktopChangedId = null;
         }
 
         override enable(): void {
@@ -188,6 +190,15 @@ const PauseOnMaximizeOrFullscreenModule = GObject.registerClass(
             this.activeWorkspaceChangedId = this.workspaceManager.connect(
                 'active-workspace-changed',
                 (wm: Meta.WorkspaceManager) => this.onActiveWorkspaceChanged(wm)
+            );
+            // The show-desktop shortcut hides windows without minimizing them,
+            // so no per-window signal fires; watch the workspace-level signal.
+            this.showingDesktopChangedId = this.workspaceManager.connect(
+                'showing-desktop-changed',
+                () => {
+                    this.logger.debug('showing-desktop changed');
+                    this.update();
+                }
             );
 
             this.activeWorkspace
@@ -284,9 +295,12 @@ const PauseOnMaximizeOrFullscreenModule = GObject.registerClass(
         }
 
         override update(): void {
+            // showing_on_its_workspace() is false for minimized windows and for
+            // windows hidden by the show-desktop shortcut, so neither counts as
+            // covering the wallpaper.
             const metaWindows = this.windows
                 .map(({metaWindow}) => metaWindow)
-                .filter(w => !w.title?.includes(APPLICATION_ID) && !w.minimized);
+                .filter(w => !w.title?.includes(APPLICATION_ID) && w.showing_on_its_workspace());
 
             const monitors = Main.layoutManager.monitors;
 
@@ -339,6 +353,8 @@ const PauseOnMaximizeOrFullscreenModule = GObject.registerClass(
 
         override disable(): void {
             this.workspaceManager?.disconnect(this.activeWorkspaceChangedId!);
+            if (this.showingDesktopChangedId !== null)
+                this.workspaceManager?.disconnect(this.showingDesktopChangedId);
             this.windows.forEach(({metaWindow, signals}) =>
                 signals.forEach(signal => metaWindow.disconnect(signal))
             );
@@ -361,6 +377,7 @@ const PauseOnMaximizeOrFullscreenModule = GObject.registerClass(
             this.overviewShowingId = null;
             this.overviewHiddenId = null;
             this.sessionModeUpdatedId = null;
+            this.showingDesktopChangedId = null;
         }
     }
 );

--- a/src/autoPause.ts
+++ b/src/autoPause.ts
@@ -122,6 +122,8 @@ const PauseOnMaximizeOrFullscreenModule = GObject.registerClass(
         private states: {
             maximizedOrFullscreenOnAnyMonitor: boolean;
             maximizedOrFullscreenOnAllMonitors: boolean;
+            inOverview: boolean;
+            onLockScreen: boolean;
         };
 
         private conditions: { pauseOnMaximizeOrFullscreen: number };
@@ -131,12 +133,17 @@ const PauseOnMaximizeOrFullscreenModule = GObject.registerClass(
         private windows: WindowEntry[];
         private windowAddedId: number | null;
         private windowRemovedId: number | null;
+        private overviewShowingId: number | null;
+        private overviewHiddenId: number | null;
+        private sessionModeUpdatedId: number | null;
 
         constructor(settings: Gio.Settings) {
             super(settings, 'maximizeOrFullscreen');
             this.states = {
                 maximizedOrFullscreenOnAnyMonitor: false,
                 maximizedOrFullscreenOnAllMonitors: false,
+                inOverview: false,
+                onLockScreen: false,
             };
             this.conditions = {
                 pauseOnMaximizeOrFullscreen: this.settings.get_int(
@@ -158,9 +165,24 @@ const PauseOnMaximizeOrFullscreenModule = GObject.registerClass(
             this.windows = [];
             this.windowAddedId = null;
             this.windowRemovedId = null;
+            this.overviewShowingId = null;
+            this.overviewHiddenId = null;
+            this.sessionModeUpdatedId = null;
         }
 
         override enable(): void {
+            this.overviewShowingId = Main.overview.connect('showing', () => {
+                this.logger.debug('overview showing');
+                this.update();
+            });
+            this.overviewHiddenId = Main.overview.connect('hidden', () => {
+                this.logger.debug('overview hidden');
+                this.update();
+            });
+            this.sessionModeUpdatedId = Main.sessionMode.connect('updated', () => {
+                this.update();
+            });
+
             this.workspaceManager = global.workspace_manager;
             this.activeWorkspace = this.workspaceManager.get_active_workspace();
             this.activeWorkspaceChangedId = this.workspaceManager.connect(
@@ -283,10 +305,21 @@ const PauseOnMaximizeOrFullscreenModule = GObject.registerClass(
                 monitor => monitorsWithMaximized[monitor.index]
             );
 
+            this.states.inOverview = Main.overview.visible;
+            this.states.onLockScreen =
+                Main.sessionMode.currentMode === 'unlock-dialog';
+
             super.update();
         }
 
         override shouldAutoPause(): boolean {
+            // Maximized/fullscreen windows don't cover the wallpaper while the
+            // overview or the lock screen is shown.
+            if (this.states.inOverview || this.states.onLockScreen) {
+                this.logger.debug('shouldAutoPause: false (overview or lock screen)');
+                return false;
+            }
+
             let res = false;
             if (
                 this.conditions.pauseOnMaximizeOrFullscreen ===
@@ -312,12 +345,22 @@ const PauseOnMaximizeOrFullscreenModule = GObject.registerClass(
             this.activeWorkspace?.disconnect(this.windowAddedId!);
             this.activeWorkspace?.disconnect(this.windowRemovedId!);
 
+            if (this.overviewShowingId !== null)
+                Main.overview.disconnect(this.overviewShowingId);
+            if (this.overviewHiddenId !== null)
+                Main.overview.disconnect(this.overviewHiddenId);
+            if (this.sessionModeUpdatedId !== null)
+                Main.sessionMode.disconnect(this.sessionModeUpdatedId);
+
             this.workspaceManager = null;
             this.activeWorkspace = null;
             this.activeWorkspaceChangedId = null;
             this.windows = [];
             this.windowAddedId = null;
             this.windowRemovedId = null;
+            this.overviewShowingId = null;
+            this.overviewHiddenId = null;
+            this.sessionModeUpdatedId = null;
         }
     }
 );


### PR DESCRIPTION
## Summary

The pause-on-maximize-or-fullscreen module paused the wallpaper even when nothing actually covered it:

- **Overview / lock screen**: maximized or fullscreen windows don't cover the wallpaper while the overview or the lock screen is shown, so the module now skips pausing there. The wallpaper resumes as soon as the overview starts showing and pauses again once it is fully hidden.
- **Show desktop (#178)**: the show-desktop shortcut hides windows *without* minimizing them, so the old `!minimized` check kept the wallpaper paused. The module now watches the workspace `showing-desktop-changed` signal and filters windows with `showing_on_its_workspace()`, which is false for both minimized and show-desktop-hidden windows.

Other auto-pause modules (focus, battery, MPRIS) are unaffected.

Fixes #178

## Changes

- fix: bypass pause on maximize or fullscreen during overview or lockscreen
- fix: resume when show desktop hides all windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)